### PR TITLE
Add multi-arch builds

### DIFF
--- a/.github/workflows/docker-dev-image.yml
+++ b/.github/workflows/docker-dev-image.yml
@@ -19,6 +19,9 @@ jobs:
           username: ${{ secrets.GHCR_LOGIN }}
           password: ${{ secrets.GHCR_PASSWORD }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2
@@ -28,9 +31,10 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: ./
+          platforms: linux/amd64,linux/arm64
           file: ./docker/Dockerfile
           push: true
           build-args:
             APP_VERSION=dev
           tags:
-            ghcr.io/buggregator/server:dev
+            ghcr.io/${{ github.repository }}:dev

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -26,6 +26,9 @@ jobs:
           username: ${{ secrets.GHCR_LOGIN }}
           password: ${{ secrets.GHCR_PASSWORD }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2
@@ -35,9 +38,10 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: ./
+          platforms: linux/amd64,linux/arm64
           file: ./docker/Dockerfile
           push: true
           build-args:
             APP_VERSION=${{ steps.previoustag.outputs.tag }}
           tags:
-            ghcr.io/buggregator/server:latest, ghcr.io/buggregator/server:${{ steps.previoustag.outputs.tag }}
+            ghcr.io/${{ github.repository }}:latest, ghcr.io/${{ github.repository }}:${{ steps.previoustag.outputs.tag }}


### PR DESCRIPTION
Hi. I'm one of those new-fangled types with an Apple Silicon mac, so I prefer to run ARM containers.

These changes to the CI jobs will build images for Apple Silicon as well as intel.

One thing I noticed, if you move a good chunk of your Dockerfile into another project, you can save a lot of build time by building the base image for the project there, and then using that image in this project.  For example, all the PHP extensions take forever to build.

Here in this project, you'd just run `composer install` and `npm install` in the image from the other (new) project.

So the flow would be `ghcr.io/roadrunner-server/roadrunner` -> `ghcr.io/buggreator/base` -> `ghcr.io/buggreator/server`
