### PR TITLE
Adds method to get current app version

### DIFF
--- a/app/src/Interfaces/Http/GetVersionAction.php
+++ b/app/src/Interfaces/Http/GetVersionAction.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interfaces\Http;
+
+use App\Application\HTTP\Response\JsonResource;
+use App\Application\HTTP\Response\ResourceInterface;
+use Spiral\Boot\EnvironmentInterface;
+use Spiral\Router\Annotation\Route;
+
+final class GetVersionAction
+{
+    #[Route(route: 'version', methods: ['GET'], group: 'api')]
+    public function __invoke(EnvironmentInterface $env): ResourceInterface
+    {
+        return new JsonResource([
+            'version' => $env->get('APP_VERSION', 'dev'),
+        ]);
+    }
+}


### PR DESCRIPTION
To get an application version a developer just need to make request

** Via HTTP**
```
GET: /api/version
```

**Via WS RPC**

```
get:api/version
```

It will response

```json
{"version":"x.x.x"}
```

#50