### PR TITLE
413 request entity too large

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,8 +28,8 @@ COPY --from=rr /usr/bin/rr /app
 ARG APP_VERSION=v1.0
 ENV COMPOSER_ALLOW_SUPERUSER=1
 
-RUN sed -i 's/memory_limit = 128M/memory_limit = 1024M/g' /usr/local/etc/php/php.ini-production && \
-    sed -i 's/post_max_size = 8M/post_max_size = 1024M/g' /usr/local/etc/php/php.ini-production && \
+RUN sed -i 's/memory_limit = 128M/memory_limit = 1024M/g' "$PHP_INI_DIR/php.ini-production" && \
+    sed -i 's/post_max_size = 8M/post_max_size = 1024M/g' "$PHP_INI_DIR/php.ini-production" && \
     mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
 WORKDIR /app

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,6 +28,10 @@ COPY --from=rr /usr/bin/rr /app
 ARG APP_VERSION=v1.0
 ENV COMPOSER_ALLOW_SUPERUSER=1
 
+RUN sed -i 's/memory_limit = 128M/memory_limit = 1024M/g' /usr/local/etc/php/php.ini-production && \
+    sed -i 's/post_max_size = 8M/post_max_size = 1024M/g' /usr/local/etc/php/php.ini-production && \
+    mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+
 WORKDIR /app
 
 RUN composer config --no-plugins allow-plugins.spiral/composer-publish-plugin false

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -8,6 +8,8 @@ server {
 
     server_name _;
 
+    client_max_body_size 1000M;
+
     location /connection {
         proxy_pass http://127.0.0.1:8089/connection;
         proxy_http_version 1.1;


### PR DESCRIPTION
Default nginx limit is 1M. Sending big profile dump/requests may go above this limit and fail. We need to increase nginx `client_max_body_size` and at the same time increase php's `max_post_size` and `memory_limit` to support it.