### PR TITLE
Fix call getValue() on null

### DIFF
--- a/app/modules/Smtp/Application/Mail/Parser.php
+++ b/app/modules/Smtp/Application/Mail/Parser.php
@@ -49,7 +49,7 @@ final class Parser
 
         return new Message(
             $this->storage->bucket('attachments'),
-            $message->getHeader('Message - Id')->getValue(),
+            $message->getHeader('Message - Id')?->getValue(),
             $body, $from, $recipients, $ccs, $subject,
             $html, $text, $replyTo, $allRecipients, $attachments
         );


### PR DESCRIPTION
When testing email sending with Magento i stumbled upon
> 	Error: Call to a member function getValue() on null in /app/app/modules/Smtp/Application/Mail/Parser.php at line 52

This is because no `Message - Id` header is present, and it does not seem needed when checking the Message class.
Thus i've simply return null if getHeader results in null