### PR TITLE
Add support for Auth0 user authentication

### DIFF
--- a/app/src/Application/Auth/AuthSettings.php
+++ b/app/src/Application/Auth/AuthSettings.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Auth;
+
+use Psr\Http\Message\UriInterface;
+
+final class AuthSettings
+{
+    public function __construct(
+        public readonly bool $enabled,
+        public readonly UriInterface $loginUrl,
+    ) {
+    }
+}

--- a/app/src/Application/Auth/JWTTokenStorage.php
+++ b/app/src/Application/Auth/JWTTokenStorage.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Auth;
+
+use Spiral\Auth\TokenInterface;
+use Spiral\Auth\TokenStorageInterface;
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
+use Firebase\JWT\ExpiredException;
+
+final class JWTTokenStorage implements TokenStorageInterface
+{
+    /** @var callable */
+    private $time;
+
+    public function __construct(
+        private readonly string $secret,
+        private readonly string $algorithm = 'HS256',
+        private readonly string $expiresAt = '+30 days',
+        callable $time = null
+    ) {
+        $this->time = $time ?? static function (string $offset): \DateTimeImmutable {
+            return new \DateTimeImmutable($offset);
+        };
+    }
+
+    public function load(string $id): ?TokenInterface
+    {
+        try {
+            $token = (array) JWT::decode($id, new Key($this->secret, $this->algorithm));
+        } catch (ExpiredException $exception) {
+            throw $exception;
+        } catch (\Throwable $exception) {
+            return null;
+        }
+
+        if (
+            false === isset($token['data'])
+            || false === isset($token['iat'])
+            || false === isset($token['exp'])
+        ) {
+            return null;
+        }
+
+        return new Token(
+            $id,
+            $token,
+            (array) $token['data'],
+            (new \DateTimeImmutable())->setTimestamp($token['iat']),
+            (new \DateTimeImmutable())->setTimestamp($token['exp'])
+        );
+    }
+
+    public function create(array $payload, \DateTimeInterface $expiresAt = null): TokenInterface
+    {
+        $issuedAt = ($this->time)('now');
+        $expiresAt = $expiresAt ?? ($this->time)($this->expiresAt);
+        $token = [
+            'iat' => $issuedAt->getTimestamp(),
+            'exp' => $expiresAt->getTimestamp(),
+            'data' => $payload,
+        ];
+
+        return new Token(
+            JWT::encode($token,$this->secret,$this->algorithm),
+            $token,
+            $payload,
+            $issuedAt,
+            $expiresAt
+        );
+    }
+
+    public function delete(TokenInterface $token): void
+    {
+        // We don't need to do anything here since JWT tokens are self-contained.
+    }
+}

--- a/app/src/Application/Auth/SuccessRedirect.php
+++ b/app/src/Application/Auth/SuccessRedirect.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Auth;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\UriInterface;
+use Spiral\Http\ResponseWrapper;
+
+final class SuccessRedirect
+{
+    public function __construct(
+        private readonly ResponseWrapper $response,
+        private readonly UriInterface $redirectUrl,
+    ) {
+    }
+
+    public function makeResponse(string $token): ResponseInterface
+    {
+        return $this->response->redirect($this->redirectUrl . '?token=' . $token);
+    }
+}

--- a/app/src/Application/Auth/Token.php
+++ b/app/src/Application/Auth/Token.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Auth;
+
+use Spiral\Auth\TokenInterface;
+
+final class Token implements TokenInterface
+{
+    public function __construct(
+        private readonly string $id,
+        private readonly array $token,
+        private readonly array $payload,
+        private readonly \DateTimeImmutable $issuedAt,
+        private readonly \DateTimeImmutable $expiresAt,
+    ) {
+    }
+
+    public function getID(): string
+    {
+        return $this->id;
+    }
+
+    public function getToken(): array
+    {
+        return $this->token;
+    }
+
+    public function getPayload(): array
+    {
+        return $this->payload;
+    }
+
+    public function getIssuedAt(): \DateTimeImmutable
+    {
+        return $this->issuedAt;
+    }
+
+    public function getExpiresAt(): \DateTimeInterface
+    {
+        return $this->expiresAt;
+    }
+}

--- a/app/src/Application/Bootloader/AuthBootloader.php
+++ b/app/src/Application/Bootloader/AuthBootloader.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Bootloader;
+
+use App\Application\Auth\AuthSettings;
+use App\Application\Auth\JWTTokenStorage;
+use App\Application\Auth\SuccessRedirect;
+use App\Application\OAuth\ActorProvider;
+use App\Application\OAuth\SessionStore;
+use Psr\Http\Message\UriFactoryInterface;
+use Spiral\Boot\Bootloader\Bootloader;
+
+use Auth0\SDK\Auth0;
+use Auth0\SDK\Configuration\SdkConfiguration;
+use Spiral\Boot\EnvironmentInterface;
+use Spiral\Bootloader\Auth\HttpAuthBootloader;
+use Spiral\Core\Container\Autowire;
+use Spiral\Http\ResponseWrapper;
+use Spiral\Session\SessionScope;
+
+final class AuthBootloader extends Bootloader
+{
+    public function defineSingletons(): array
+    {
+        return [
+            SdkConfiguration::class => static fn(EnvironmentInterface $env) => new SdkConfiguration(
+                strategy: $env->get('AUTH_STRATEGY', SdkConfiguration::STRATEGY_REGULAR),
+                domain: $env->get('AUTH_PROVIDER_URL'),
+                clientId: $env->get('AUTH_CLIENT_ID'),
+                redirectUri: $env->get('AUTH_CALLBACK_URL'),
+                clientSecret: $env->get('AUTH_CLIENT_SECRET'),
+                scope: \explode(',', $env->get('AUTH_SCOPES', 'openid,profile,email')),
+                cookieSecret: $env->get('AUTH_COOKIE_SECRET', $env->get('ENCRYPTER_KEY') ?? 'secret'),
+            ),
+
+            Auth0::class => static fn(SdkConfiguration $config, SessionScope $session) => new Auth0(
+                $config->setTransientStorage(new SessionStore($session)),
+            ),
+
+            AuthSettings::class => static fn(
+                EnvironmentInterface $env,
+                UriFactoryInterface $factory,
+            ) => new AuthSettings(
+                enabled: $env->get('AUTH_ENABLED', false),
+                loginUrl: $factory->createUri('/auth/sso/login'),
+            ),
+
+            SuccessRedirect::class => static fn(
+                UriFactoryInterface $factory,
+                ResponseWrapper $response,
+            ) => new SuccessRedirect(
+                response: $response,
+                redirectUrl: $factory->createUri('/#/login'),
+            ),
+        ];
+    }
+
+    public function init(
+        HttpAuthBootloader $httpAuth,
+        EnvironmentInterface $env,
+        \Spiral\Bootloader\Auth\AuthBootloader $auth,
+    ): void {
+        $auth->addActorProvider(new Autowire(ActorProvider::class));
+        $httpAuth->addTokenStorage(
+            'jwt',
+            new Autowire(
+                JWTTokenStorage::class,
+                [
+                    'secret' => $env->get('AUTH_JWT_SECRET', $env->get('ENCRYPTER_KEY')),
+                ],
+            ),
+        );
+    }
+}

--- a/app/src/Application/HTTP/Response/UserResource.php
+++ b/app/src/Application/HTTP/Response/UserResource.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\HTTP\Response;
+
+use App\Application\OAuth\User;
+
+final class UserResource extends JsonResource
+{
+    public function __construct(
+        private readonly User $user,
+    ) {
+        parent::__construct();
+    }
+
+    protected function mapData(): array
+    {
+        return [
+            'username' => $this->user->getUsername(),
+            'avatar' => $this->user->getAvatar(),
+            'email' => $this->user->getEmail(),
+        ];
+    }
+}

--- a/app/src/Application/Kernel.php
+++ b/app/src/Application/Kernel.php
@@ -6,6 +6,7 @@ namespace App\Application;
 
 use App\Application\Bootloader\AppBootloader;
 use App\Application\Bootloader\AttributesBootloader;
+use App\Application\Bootloader\AuthBootloader;
 use App\Application\Bootloader\HttpHandlerBootloader;
 use App\Application\Bootloader\MongoDBBootloader;
 use App\Application\Bootloader\PersistenceBootloader;
@@ -84,6 +85,7 @@ class Kernel extends \Spiral\Framework\Kernel
             EventsBootloader::class,
             EventBootloader::class,
             CqrsBootloader::class,
+            Framework\Http\SessionBootloader::class,
 
             // Console commands
             Framework\CommandBootloader::class,
@@ -106,6 +108,7 @@ class Kernel extends \Spiral\Framework\Kernel
             ProfilerBootloader::class,
             MongoDBBootloader::class,
             PersistenceBootloader::class,
+            AuthBootloader::class,
         ];
     }
 }

--- a/app/src/Application/OAuth/ActorProvider.php
+++ b/app/src/Application/OAuth/ActorProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\OAuth;
+
+use Auth0\SDK\Auth0;
+use Spiral\Auth\ActorProviderInterface;
+use Spiral\Auth\TokenInterface;
+
+final class ActorProvider implements ActorProviderInterface
+{
+    public function __construct(
+        private readonly Auth0 $auth,
+    ) {
+    }
+
+    public function getActor(TokenInterface $token): ?User
+    {
+        $payload = $token->getPayload();
+        if (empty($payload)) {
+            $payload = self::getGuestPayload();
+        }
+
+        return new User($payload);
+    }
+
+    public static function getGuestPayload(): array
+    {
+        return [
+            'nickname' => 'guest',
+            'email' => '',
+            'picture' => '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 144.8 144.8" xml:space="preserve"><circle style="fill:#f5c002" cx="72.4" cy="72.4" r="72.4"/><defs><circle id="a" cx="72.4" cy="72.4" r="72.4"/></defs><clipPath id="b"><use xlink:href="#a" style="overflow:visible"/></clipPath><g style="clip-path:url(#b)"><path style="fill:#f1c9a5" d="M107 117c-5-9-35-14-35-14s-30 5-34 14l-7 28h82s-2-17-6-28z"/><path style="fill:#e4b692" d="M72 103s30 5 35 14c4 11 6 28 6 28H72v-42z"/><path style="fill:#f1c9a5" d="M64 85h17v27H64z"/><path style="fill:#e4b692" d="M72 85h9v27h-9z"/><path style="opacity:.1;fill:#ddac8c" d="M64 97c2 4 8 7 12 7l5-1V85H64v12z"/><path style="fill:#f1c9a5" d="M93 67c0-17-9-26-21-26-11 0-21 9-21 26 0 23 10 31 21 31 12 0 21-9 21-31z"/><path style="fill:#e4b692" d="M90 79c-4 0-6-4-6-9 1-5 5-8 9-8 3 1 6 5 5 9 0 5-4 9-8 8z"/><path style="fill:#f1c9a5" d="M47 71c-1-4 2-8 5-9 4 0 8 3 8 8 1 5-1 9-5 9-4 1-8-3-8-8z"/><path style="fill:#e4b692" d="M93 67c0-17-9-26-21-26v57c12 0 21-9 21-31z"/><path style="fill:#303030" d="M91 82c-1 3-3 7-6 7-5 0-8-4-13-4s-8 4-12 4c-3 0-5-4-7-7v-6 7s1 8 4 11c3 2 11 6 15 6 5 0 13-4 15-6 4-3 5-11 5-11v-7l-1 6zM62 44s4 16 26 24l-3-8 10 7c3-7 7-16-2-21-8-6-28-15-31-2z"/><path style="fill:#303030" d="M55 66s2-18 8-22c-5-2-14 5-13 10l5 12z"/><path style="fill:#fb621e" d="M107 117c-3-5-14-9-23-12a12 12 0 0 1-23 0c-9 3-21 7-23 12l-7 28h82s-2-17-6-28z"/><path style="opacity:.2;fill:#e53d0c" d="M60 108c0 6 6 11 12 11 7 0 12-5 13-11 8 2 18 6 22 10v-1c-3-5-14-9-23-12a12 12 0 0 1-23 0c-9 3-21 7-23 12l-1 1c5-4 15-8 23-10z"/><path style="fill:#e53d0c" d="M57 106a15 15 0 0 0 30 0l-3-1a12 12 0 0 1-23 0l-4 1z"/><path style="fill:#fff" d="M76 91s-1-3-4-3c-2 0-3 3-3 3h7z"/></g></svg>',
+        ];
+    }
+}

--- a/app/src/Application/OAuth/SessionStore.php
+++ b/app/src/Application/OAuth/SessionStore.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\OAuth;
+
+use Auth0\SDK\Contract\StoreInterface;
+use Spiral\Session\SessionInterface;
+
+final class SessionStore implements StoreInterface
+{
+    public function __construct(
+        private readonly SessionInterface $session,
+        private readonly string $sessionPrefix = 'auth0',
+    ) {
+    }
+
+    /**
+     * This has no effect when using sessions as the storage medium.
+     *
+     * @param bool $deferring whether to defer persisting the storage state
+     *
+     * @codeCoverageIgnore
+     */
+    public function defer(
+        bool $deferring,
+    ): void {
+    }
+
+    /**
+     * Removes a persisted value identified by $key.
+     *
+     * @param string $key session key to delete
+     */
+    public function delete(
+        string $key,
+    ): void {
+        $this->session->getSection($this->sessionPrefix)->delete($key);
+    }
+
+    /**
+     * Gets persisted values identified by $key.
+     * If the value is not set, returns $default.
+     *
+     * @param string $key session key to set
+     * @param mixed $default default to return if nothing was found
+     *
+     * @return mixed
+     */
+    public function get(
+        string $key,
+        $default = null,
+    ) {
+        return $this->session->getSection($this->sessionPrefix)->get($key, $default);
+    }
+
+    /**
+     * Removes all persisted values.
+     */
+    public function purge(): void
+    {
+        $this->session->getSection($this->sessionPrefix)->clear();
+    }
+
+    /**
+     * Persists $value on $_SESSION, identified by $key.
+     *
+     * @param string $key session key to set
+     * @param mixed $value value to use
+     */
+    public function set(
+        string $key,
+        $value,
+    ): void {
+        $this->session->getSection($this->sessionPrefix)->set($key, $value);
+    }
+
+    /**
+     * This basic implementation of BaseAuth0 SDK uses PHP Sessions to store volatile data.
+     */
+    public function start(): void
+    {
+    }
+}

--- a/app/src/Application/OAuth/User.php
+++ b/app/src/Application/OAuth/User.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\OAuth;
+
+final class User
+{
+    public function __construct(
+        private readonly array $data,
+    ) {
+    }
+
+    public function getUsername(): string
+    {
+        return $this->data['nickname'] ?? 'guest';
+    }
+
+    public function getAvatar(): string
+    {
+        return $this->data['picture'];
+    }
+
+    public function getEmail(): string
+    {
+        return $this->data['email'];
+    }
+}

--- a/app/src/Interfaces/Http/Controller/Auth/CallbackAction.php
+++ b/app/src/Interfaces/Http/Controller/Auth/CallbackAction.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interfaces\Http\Controller\Auth;
+
+use App\Application\Auth\SuccessRedirect;
+use Auth0\SDK\Auth0;
+use Psr\Http\Message\ResponseInterface;
+use Spiral\Auth\AuthScope;
+use Spiral\Auth\TokenStorageInterface;
+use Spiral\Http\Request\InputManager;
+use Spiral\Router\Annotation\Route;
+
+final class CallbackAction
+{
+    #[Route(route: 'auth/sso/callback', methods: ['GET'], group: 'guest')]
+    public function __invoke(
+        Auth0 $auth,
+        InputManager $input,
+        AuthScope $authScope,
+        TokenStorageInterface $tokens,
+        SuccessRedirect $successRedirect,
+    ): ResponseInterface {
+        $auth->exchange(
+            code: $input->query('code'),
+            state: $input->query('state'),
+        );
+
+        $authScope->start(
+            $token = $tokens->create($auth->getUser()),
+        );
+
+        return $successRedirect->makeResponse($token->getID());
+    }
+}

--- a/app/src/Interfaces/Http/Controller/Auth/LoginAction.php
+++ b/app/src/Interfaces/Http/Controller/Auth/LoginAction.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interfaces\Http\Controller\Auth;
+
+use App\Application\Auth\SuccessRedirect;
+use Auth0\SDK\Auth0;
+use Psr\Http\Message\ResponseInterface;
+use Spiral\Auth\AuthScope;
+use Spiral\Auth\TokenStorageInterface;
+use Spiral\Http\ResponseWrapper;
+use Spiral\Router\Annotation\Route;
+
+final class LoginAction
+{
+    public function __construct(
+        private readonly ResponseWrapper $response,
+    ) {
+    }
+
+    #[Route(route: 'auth/sso/login', methods: ['GET'], group: 'guest')]
+    public function __invoke(
+        Auth0 $auth,
+        AuthScope $authScope,
+        TokenStorageInterface $tokens,
+        SuccessRedirect $successRedirect,
+    ): ResponseInterface {
+        $session = $auth->getCredentials();
+
+        if (null === $session || $session->accessTokenExpired) {
+            return $this->response->redirect($auth->login());
+        }
+
+        $authScope->start(
+            $token = $tokens->create($auth->getUser()),
+        );
+
+        return $successRedirect->makeResponse($token->getID());
+    }
+}

--- a/app/src/Interfaces/Http/Controller/Auth/MeAction.php
+++ b/app/src/Interfaces/Http/Controller/Auth/MeAction.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interfaces\Http\Controller\Auth;
+
+use App\Application\HTTP\Response\ResourceInterface;
+use App\Application\HTTP\Response\UserResource;
+use App\Application\OAuth\ActorProvider;
+use App\Application\OAuth\User;
+use Spiral\Auth\AuthScope;
+use Spiral\Router\Annotation\Route;
+
+final class MeAction
+{
+    #[Route(route: 'me', methods: ['GET'], group: 'api')]
+    public function __invoke(
+        AuthScope $authScope,
+    ): ResourceInterface {
+        /** @var User $actor */
+        $actor = $authScope->getActor() ?? new User(ActorProvider::getGuestPayload());
+
+        return new UserResource($actor);
+    }
+}

--- a/app/src/Interfaces/Http/Controller/GetVersionAction.php
+++ b/app/src/Interfaces/Http/Controller/GetVersionAction.php
@@ -11,7 +11,7 @@ use Spiral\Router\Annotation\Route;
 
 final class GetVersionAction
 {
-    #[Route(route: 'version', methods: ['GET'], group: 'api')]
+    #[Route(route: 'version', methods: ['GET'], group: 'api_guest')]
     public function __invoke(EnvironmentInterface $env): ResourceInterface
     {
         return new JsonResource([

--- a/app/src/Interfaces/Http/Controller/SettingsAction.php
+++ b/app/src/Interfaces/Http/Controller/SettingsAction.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interfaces\Http\Controller;
+
+use App\Application\Auth\AuthSettings;
+use App\Application\HTTP\Response\JsonResource;
+use App\Application\HTTP\Response\ResourceInterface;
+use Spiral\Boot\EnvironmentInterface;
+use Spiral\Router\Annotation\Route;
+
+final class SettingsAction
+{
+    #[Route(route: 'settings', methods: ['GET'], group: 'api_guest')]
+    public function __invoke(EnvironmentInterface $env, AuthSettings $settings): ResourceInterface
+    {
+        return new JsonResource([
+            'auth' => [
+                'enabled' => $settings->enabled,
+                'login_url' => (string) $settings->loginUrl,
+            ],
+            'version' => $env->get('APP_VERSION', 'dev'),
+        ]);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,10 @@
     "require": {
         "php": ">=8.1",
         "ext-mbstring": "*",
+        "auth0/auth0-php": "^8.11",
         "doctrine/collections": "^1.8",
+        "firebase/php-jwt": "^6.10",
+        "guzzlehttp/guzzle": "^7.8",
         "nesbot/carbon": "^2.64",
         "php-http/message": "^1.11",
         "spiral-packages/cqrs": "^2.0",


### PR DESCRIPTION
This commit introduces the integration of the [Auth0](https://auth0.com/) authentication provider into our application. Users can now authenticate using Auth0, which provides a secure and reliable means of handling user authentication.

To enable authentication you need to set ENV variables

```
AUTH_ENABLED=true
AUTH_PROVIDER_URL=https://xxx.auth0.com
AUTH_CLIENT_ID=xxx
AUTH_CLIENT_SECRET=xxx
AUTH_CALLBACK_URL=http://local.server/auth/sso/callback
AUTH_SCOPES=openid,email,profile
```

![image](https://github.com/buggregator/server/assets/773481/ed877a52-32f4-423a-a08f-f8bb9f9b792c)
