### PR TITLE
Added functionality to configure external databases for event storage

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -39,3 +39,18 @@ CYCLE_SCHEMA_WARMUP=false
 # Sentry
 SENTRY_JS_SDK_URL=https://browser.sentry-cdn.com/7.69.0/bundle.tracing.replay.min.js
 SENTRY_DSN_HOST=http://sentry@127.0.0.1:8082
+
+# Persistence
+PERSISTENCE_DRIVER=cache
+
+# PERSISTENCE_DRIVER=database
+DB_DRIVER=pgsql # mysql, pgsql
+DB_DATABASE=buggregator
+DB_HOST=127.0.0.1
+DB_PORT=5432
+DB_USERNAME=homestead
+DB_PASSWORD=secret
+
+# PERSISTENCE_DRIVER=mongodb
+MONGODB_CONNECTION=mongodb://127.0.0.1:27017
+MONGODB_DATABASE=buggregator

--- a/app/config/database.php
+++ b/app/config/database.php
@@ -6,10 +6,8 @@ use Cycle\Database\Config;
 
 return [
     'logger' => [
-        'default' => null,
-        'drivers' => [
-            // 'runtime' => 'stdout'
-        ],
+        'default' => env('DB_LOGGER'),
+        'drivers' => [],
     ],
 
     /**
@@ -27,7 +25,7 @@ return [
      */
     'databases' => [
         'default' => [
-            'driver' => 'runtime',
+            'driver' => env('DB_DRIVER', 'pgsql'),
         ],
     ],
 
@@ -38,12 +36,34 @@ return [
      * the driver class and its connection options.
      */
     'drivers' => [
-        'runtime' => new Config\SQLiteDriverConfig(
-            connection: new Config\SQLite\FileConnectionConfig(
-                database: '/dev/shm/buggregator'
+        'pgsql' => new Config\PostgresDriverConfig(
+            connection: new Config\Postgres\TcpConnectionConfig(
+                database: env('DB_DATABASE', 'buggregator'),
+                host: env('DB_HOST', '127.0.0.1'),
+                port: env('DB_PORT', 5432),
+                user: env('DB_USERNAME', 'postgres'),
+                password: env('DB_PASSWORD'),
             ),
-            queryCache: true
+            schema: 'public',
+            queryCache: true,
+            options: [
+                'withDatetimeMicroseconds' => true,
+                'logQueryParameters' => env('DB_LOG_QUERY_PARAMETERS', false),
+            ],
         ),
-        // ...
+        'mysql' => new Config\MySQLDriverConfig(
+            connection: new Config\MySQL\TcpConnectionConfig(
+                database: env('DB_DATABASE', 'buggregator'),
+                host: env('DB_HOST', '127.0.0.1'),
+                port: env('DB_PORT', 5432),
+                user: env('DB_USERNAME', 'postgres'),
+                password: env('DB_PASSWORD'),
+            ),
+            queryCache: true,
+            options: [
+                'withDatetimeMicroseconds' => true,
+                'logQueryParameters' => env('DB_LOG_QUERY_PARAMETERS', false),
+            ],
+        ),
     ],
 ];

--- a/app/src/Application/Bootloader/PersistenceBootloader.php
+++ b/app/src/Application/Bootloader/PersistenceBootloader.php
@@ -38,7 +38,7 @@ final class PersistenceBootloader extends Bootloader
         EnvironmentInterface $env
     ): EventRepositoryInterface {
         return match ($env->get('PERSISTENCE_DRIVER', 'cache')) {
-            'cycle' => $factory->make(CycleOrmEventRepository::class),
+            'database' => $factory->make(CycleOrmEventRepository::class),
             'mongodb' => $factory->make(MongoDBEventRepository::class),
             'cache' => $factory->make(CacheEventRepository::class),
             default => throw new \InvalidArgumentException('Unknown persistence driver'),

--- a/app/src/Application/Persistence/MongoDBEventRepository.php
+++ b/app/src/Application/Persistence/MongoDBEventRepository.php
@@ -6,7 +6,6 @@ namespace App\Application\Persistence;
 
 use App\Application\Domain\Entity\Json;
 use App\Application\Domain\ValueObjects\Uuid;
-use Carbon\Carbon;
 use Modules\Events\Domain\Event;
 use Modules\Events\Domain\EventRepositoryInterface;
 use MongoDB\Collection;

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,6 +22,7 @@ COPY --from=git /app /app
 COPY --from=frontend /app /app/frontend
 COPY --from=rr /usr/bin/rr /app
 COPY --from=centrifugo /usr/local/bin/centrifugo /app/bin
+COPY --from=git /app/docker/entrypoint.sh /app
 
 ARG APP_VERSION=v1.0
 ENV COMPOSER_ALLOW_SUPERUSER=1
@@ -65,4 +66,4 @@ LABEL org.opencontainers.image.source=$REPOSITORY
 LABEL org.opencontainers.image.description="Buggregator"
 LABEL org.opencontainers.image.licenses=MIT
 
-CMD ./rr serve -c .rr-prod.yaml
+CMD ["entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+php app.php configure
+php app.php migrate --force
+
+# serve server
+./rr serve -c .rr-prod.yaml


### PR DESCRIPTION
This commit introduces the ability to configure an external database for storing events. The configuration can be done via environment variables, allowing the use of different types of databases such as MongoDB, PostgreSQL, or MySQL.

By default, all events are stored in a local in-memory storage. However, with this update, users can now opt to use an external database by setting the `PERSISTENCE_DRIVER` environment variable to `database` or `mongodb` and providing the necessary database connection details.  

### Database

```dotenv
PERSISTENCE_DRIVER=database
DB_DRIVER=pgsql # mysql, pgsql
DB_DATABASE=buggregator
DB_HOST=127.0.0.1
DB_PORT=5432
DB_USERNAME=homestead
DB_PASSWORD=secret
```

### MongoDB

```dotenv
PERSISTENCE_DRIVER=mongodb
MONGODB_CONNECTION=mongodb://127.0.0.1:27017
MONGODB_DATABASE=buggregator
```


This enhancement provides more flexibility in terms of data persistence and storage options for events."