### PR TITLE
feat: add ability to set IDE url template

### DIFF
--- a/app/src/Application/AppVersion.php
+++ b/app/src/Application/AppVersion.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application;
+
+use Spiral\Core\Attribute\Singleton;
+
+#[Singleton]
+final readonly class AppVersion
+{
+    public function __construct(
+        public string $version,
+    ) {
+    }
+}

--- a/app/src/Application/Bootloader/AppBootloader.php
+++ b/app/src/Application/Bootloader/AppBootloader.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace App\Application\Bootloader;
 
+use App\Application\AppVersion;
 use App\Application\HTTP\Interceptor\JsonResourceInterceptor;
 use App\Application\HTTP\Interceptor\StringToIntParametersInterceptor;
 use App\Application\HTTP\Interceptor\UuidParametersConverterInterceptor;
+use App\Application\Ide\UrlTemplate;
+use Spiral\Boot\EnvironmentInterface;
 use Spiral\Bootloader\DomainBootloader;
 use Spiral\Core\CoreInterface;
 
@@ -15,7 +18,23 @@ final class AppBootloader extends DomainBootloader
     public function defineSingletons(): array
     {
         return [
-            CoreInterface::class => fn(\Spiral\Core\Core $core, \Psr\Container\ContainerInterface $container, ?\Psr\EventDispatcher\EventDispatcherInterface $dispatcher = null): \Spiral\Core\InterceptableCore => self::domainCore($core, $container, $dispatcher),
+            CoreInterface::class => fn(
+                \Spiral\Core\Core $core,
+                \Psr\Container\ContainerInterface $container,
+                ?\Psr\EventDispatcher\EventDispatcherInterface $dispatcher = null,
+            ): \Spiral\Core\InterceptableCore => self::domainCore($core, $container, $dispatcher),
+
+            UrlTemplate::class => fn(
+                EnvironmentInterface $env,
+            ): UrlTemplate => new UrlTemplate(
+                template: $env->get('IDE_URL_TEMPLATE', 'phpstorm://open?url=file://%s&line=%d'),
+            ),
+
+            AppVersion::class => fn(
+                EnvironmentInterface $env,
+            ): AppVersion => new AppVersion(
+                version: $env->get('APP_VERSION', 'dev'),
+            ),
         ];
     }
 

--- a/app/src/Application/Ide/UrlTemplate.php
+++ b/app/src/Application/Ide/UrlTemplate.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Ide;
+
+use Spiral\Core\Attribute\Singleton;
+
+#[Singleton]
+final readonly class UrlTemplate
+{
+    public function __construct(
+        public string $template,
+    ) {
+    }
+}

--- a/app/src/Interfaces/Http/Controller/SettingsAction.php
+++ b/app/src/Interfaces/Http/Controller/SettingsAction.php
@@ -4,23 +4,33 @@ declare(strict_types=1);
 
 namespace App\Interfaces\Http\Controller;
 
+use App\Application\AppVersion;
 use App\Application\Auth\AuthSettings;
 use App\Application\HTTP\Response\JsonResource;
 use App\Application\HTTP\Response\ResourceInterface;
+use App\Application\Ide\UrlTemplate;
 use Spiral\Boot\EnvironmentInterface;
 use Spiral\Router\Annotation\Route;
 
 final class SettingsAction
 {
     #[Route(route: 'settings', methods: ['GET'], group: 'api_guest')]
-    public function __invoke(EnvironmentInterface $env, AuthSettings $settings): ResourceInterface
+    public function __invoke(
+        EnvironmentInterface $env,
+        AuthSettings $settings,
+        UrlTemplate $ideUrl,
+        AppVersion $appVersion,
+    ): ResourceInterface
     {
         return new JsonResource([
             'auth' => [
                 'enabled' => $settings->enabled,
-                'login_url' => (string) $settings->loginUrl,
+                'login_url' => (string)$settings->loginUrl,
             ],
-            'version' => $env->get('APP_VERSION', 'dev'),
+            'ide' => [
+                'url_template' => $ideUrl->template,
+            ],
+            'version' => $appVersion->version,
         ]);
     }
 }


### PR DESCRIPTION
By default is used template for PHPStorm

> The phpstorm option is supported natively by PhpStorm on macOS and Windows; Linux requires installing [phpstorm-url-handler](https://github.com/sanduhrs/phpstorm-url-handler).

```dotenv
IDE_URL_TEMPLATE=phpstorm://open?url=file://${file}&line=${line}
```

If you use another editor, the expected configuration value is a URL template that contains an `${file}` placeholder where the file path is expected and `${line}` placeholder for the line number.

Env variable can be set  into the Buggregator Docker container like this:

```yaml
buggregator-server:
  ...
  environment:
    IDE_URL_TEMPLATE: phpstorm://open?url=file://${file}&line=${line}
```