### PR TITLE
Adds Kinde auth support

### DIFF
--- a/app/src/Application/Auth/JWTTokenStorage.php
+++ b/app/src/Application/Auth/JWTTokenStorage.php
@@ -51,7 +51,7 @@ final class JWTTokenStorage implements TokenStorageInterface
         );
     }
 
-    public function create(array $payload, \DateTimeInterface $expiresAt = null): TokenInterface
+    public function create(array|\JsonSerializable $payload, \DateTimeInterface $expiresAt = null): TokenInterface
     {
         $issuedAt = ($this->time)('now');
         $expiresAt = $expiresAt ?? ($this->time)($this->expiresAt);

--- a/app/src/Application/Bootloader/RoutesBootloader.php
+++ b/app/src/Application/Bootloader/RoutesBootloader.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace App\Application\Bootloader;
 
 use App\Application\Auth\AuthSettings;
+use App\Application\HTTP\Middleware\ApiAuthMiddleware;
 use App\Application\HTTP\Middleware\DetectEventTypeMiddleware;
 use App\Application\HTTP\Middleware\JsonPayloadMiddleware;
 use App\Interfaces\Http\EventHandlerAction;
-use Spiral\Auth\Middleware\AuthMiddleware;
 use Spiral\Auth\Middleware\Firewall\ExceptionFirewall;
 use Spiral\Bootloader\Http\RoutesBootloader as BaseRoutesBootloader;
 use Spiral\Core\Container;
@@ -56,7 +56,7 @@ final class RoutesBootloader extends BaseRoutesBootloader
     {
         return [
             'auth' => [
-                AuthMiddleware::class,
+                ApiAuthMiddleware::class,
             ],
             'guest' => [
                 'middleware:auth',

--- a/app/src/Application/Exception/AuthProviderException.php
+++ b/app/src/Application/Exception/AuthProviderException.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Exception;
+
+class AuthProviderException extends \Exception {}

--- a/app/src/Application/Exception/AuthProviderNotFound.php
+++ b/app/src/Application/Exception/AuthProviderNotFound.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Exception;
+
+final class AuthProviderNotFound extends AuthProviderException {}

--- a/app/src/Application/Exception/InvalidCredentialsException.php
+++ b/app/src/Application/Exception/InvalidCredentialsException.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Exception;
+
+final class InvalidCredentialsException extends AuthProviderException {}

--- a/app/src/Application/HTTP/Middleware/ApiAuthMiddleware.php
+++ b/app/src/Application/HTTP/Middleware/ApiAuthMiddleware.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\HTTP\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Spiral\Auth\Middleware\AuthTransportWithStorageMiddleware;
+use Spiral\Core\FactoryInterface;
+
+final class ApiAuthMiddleware implements MiddlewareInterface
+{
+    private ?MiddlewareInterface $middleware = null;
+
+    public function __construct(
+        private readonly FactoryInterface $factory,
+    ) {}
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        if ($this->middleware === null) {
+            $this->initMiddleware();
+        }
+
+        return $this->middleware->process($request, $handler);
+    }
+
+    private function initMiddleware(): void
+    {
+        $this->middleware = $this->factory->make(AuthTransportWithStorageMiddleware::class, [
+            'transportName' => 'header',
+        ]);
+    }
+}

--- a/app/src/Application/HTTP/Response/UserResource.php
+++ b/app/src/Application/HTTP/Response/UserResource.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace App\Application\HTTP\Response;
 
 use App\Application\OAuth\User;
+use Psr\Http\Message\UriInterface;
 
 final class UserResource extends JsonResource
 {
     public function __construct(
         private readonly User $user,
+        private readonly ?UriInterface $logoutUrl = null,
     ) {
         parent::__construct();
     }
@@ -17,9 +19,11 @@ final class UserResource extends JsonResource
     protected function mapData(): array
     {
         return [
-            'username' => $this->user->getUsername(),
-            'avatar' => $this->user->getAvatar(),
-            'email' => $this->user->getEmail(),
+            'provider' => $this->user->provider,
+            'username' => $this->user->username,
+            'avatar' => $this->user->avatar,
+            'email' => $this->user->email,
+            'logout' => $this->logoutUrl ? (string) $this->logoutUrl : null,
         ];
     }
 }

--- a/app/src/Application/Kernel.php
+++ b/app/src/Application/Kernel.php
@@ -11,6 +11,8 @@ use App\Application\Bootloader\BroadcastingBootloader;
 use App\Application\Bootloader\HttpHandlerBootloader;
 use App\Application\Bootloader\MongoDBBootloader;
 use App\Application\Bootloader\PersistenceBootloader;
+use App\Integration\Auth0\Auth0Bootloader;
+use App\Integration\Kinde\KindeBootloader;
 use Modules\Events\Application\EventsBootloader;
 use Modules\Inspector\Application\InspectorBootloader;
 use Modules\Metrics\Application\MetricsBootloader;
@@ -83,6 +85,10 @@ class Kernel extends \Spiral\Framework\Kernel
             SerializerBootloader::class,
             BroadcastingBootloader::class,
 
+            // Auth
+            Auth0Bootloader::class,
+            KindeBootloader::class,
+
             // Modules
             HttpHandlerBootloader::class,
             AppBootloader::class,
@@ -95,7 +101,6 @@ class Kernel extends \Spiral\Framework\Kernel
             ProfilerBootloader::class,
             MongoDBBootloader::class,
             PersistenceBootloader::class,
-            AuthBootloader::class,
             WebhooksBootloader::class,
             ProjectBootloader::class,
             EventsBootloader::class,

--- a/app/src/Application/OAuth/ActorProvider.php
+++ b/app/src/Application/OAuth/ActorProvider.php
@@ -7,24 +7,25 @@ namespace App\Application\OAuth;
 use Spiral\Auth\ActorProviderInterface;
 use Spiral\Auth\TokenInterface;
 
-final class ActorProvider implements ActorProviderInterface
+final readonly class ActorProvider implements ActorProviderInterface
 {
     public function getActor(TokenInterface $token): ?User
     {
         $payload = $token->getPayload();
         if ($payload === []) {
-            $payload = self::getGuestPayload();
+            return self::getGuestPayload();
         }
 
-        return new User($payload);
+        return User::fromArray($payload);
     }
 
-    public static function getGuestPayload(): array
+    public static function getGuestPayload(): User
     {
-        return [
-            'nickname' => 'guest',
-            'email' => '',
-            'picture' => '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 144.8 144.8" xml:space="preserve"><circle style="fill:#f5c002" cx="72.4" cy="72.4" r="72.4"/><defs><circle id="a" cx="72.4" cy="72.4" r="72.4"/></defs><clipPath id="b"><use xlink:href="#a" style="overflow:visible"/></clipPath><g style="clip-path:url(#b)"><path style="fill:#f1c9a5" d="M107 117c-5-9-35-14-35-14s-30 5-34 14l-7 28h82s-2-17-6-28z"/><path style="fill:#e4b692" d="M72 103s30 5 35 14c4 11 6 28 6 28H72v-42z"/><path style="fill:#f1c9a5" d="M64 85h17v27H64z"/><path style="fill:#e4b692" d="M72 85h9v27h-9z"/><path style="opacity:.1;fill:#ddac8c" d="M64 97c2 4 8 7 12 7l5-1V85H64v12z"/><path style="fill:#f1c9a5" d="M93 67c0-17-9-26-21-26-11 0-21 9-21 26 0 23 10 31 21 31 12 0 21-9 21-31z"/><path style="fill:#e4b692" d="M90 79c-4 0-6-4-6-9 1-5 5-8 9-8 3 1 6 5 5 9 0 5-4 9-8 8z"/><path style="fill:#f1c9a5" d="M47 71c-1-4 2-8 5-9 4 0 8 3 8 8 1 5-1 9-5 9-4 1-8-3-8-8z"/><path style="fill:#e4b692" d="M93 67c0-17-9-26-21-26v57c12 0 21-9 21-31z"/><path style="fill:#303030" d="M91 82c-1 3-3 7-6 7-5 0-8-4-13-4s-8 4-12 4c-3 0-5-4-7-7v-6 7s1 8 4 11c3 2 11 6 15 6 5 0 13-4 15-6 4-3 5-11 5-11v-7l-1 6zM62 44s4 16 26 24l-3-8 10 7c3-7 7-16-2-21-8-6-28-15-31-2z"/><path style="fill:#303030" d="M55 66s2-18 8-22c-5-2-14 5-13 10l5 12z"/><path style="fill:#fb621e" d="M107 117c-3-5-14-9-23-12a12 12 0 0 1-23 0c-9 3-21 7-23 12l-7 28h82s-2-17-6-28z"/><path style="opacity:.2;fill:#e53d0c" d="M60 108c0 6 6 11 12 11 7 0 12-5 13-11 8 2 18 6 22 10v-1c-3-5-14-9-23-12a12 12 0 0 1-23 0c-9 3-21 7-23 12l-1 1c5-4 15-8 23-10z"/><path style="fill:#e53d0c" d="M57 106a15 15 0 0 0 30 0l-3-1a12 12 0 0 1-23 0l-4 1z"/><path style="fill:#fff" d="M76 91s-1-3-4-3c-2 0-3 3-3 3h7z"/></g></svg>',
-        ];
+        return new User(
+            provider: null,
+            username: 'guest',
+            avatar: '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 144.8 144.8" xml:space="preserve"><circle style="fill:#f5c002" cx="72.4" cy="72.4" r="72.4"/><defs><circle id="a" cx="72.4" cy="72.4" r="72.4"/></defs><clipPath id="b"><use xlink:href="#a" style="overflow:visible"/></clipPath><g style="clip-path:url(#b)"><path style="fill:#f1c9a5" d="M107 117c-5-9-35-14-35-14s-30 5-34 14l-7 28h82s-2-17-6-28z"/><path style="fill:#e4b692" d="M72 103s30 5 35 14c4 11 6 28 6 28H72v-42z"/><path style="fill:#f1c9a5" d="M64 85h17v27H64z"/><path style="fill:#e4b692" d="M72 85h9v27h-9z"/><path style="opacity:.1;fill:#ddac8c" d="M64 97c2 4 8 7 12 7l5-1V85H64v12z"/><path style="fill:#f1c9a5" d="M93 67c0-17-9-26-21-26-11 0-21 9-21 26 0 23 10 31 21 31 12 0 21-9 21-31z"/><path style="fill:#e4b692" d="M90 79c-4 0-6-4-6-9 1-5 5-8 9-8 3 1 6 5 5 9 0 5-4 9-8 8z"/><path style="fill:#f1c9a5" d="M47 71c-1-4 2-8 5-9 4 0 8 3 8 8 1 5-1 9-5 9-4 1-8-3-8-8z"/><path style="fill:#e4b692" d="M93 67c0-17-9-26-21-26v57c12 0 21-9 21-31z"/><path style="fill:#303030" d="M91 82c-1 3-3 7-6 7-5 0-8-4-13-4s-8 4-12 4c-3 0-5-4-7-7v-6 7s1 8 4 11c3 2 11 6 15 6 5 0 13-4 15-6 4-3 5-11 5-11v-7l-1 6zM62 44s4 16 26 24l-3-8 10 7c3-7 7-16-2-21-8-6-28-15-31-2z"/><path style="fill:#303030" d="M55 66s2-18 8-22c-5-2-14 5-13 10l5 12z"/><path style="fill:#fb621e" d="M107 117c-3-5-14-9-23-12a12 12 0 0 1-23 0c-9 3-21 7-23 12l-7 28h82s-2-17-6-28z"/><path style="opacity:.2;fill:#e53d0c" d="M60 108c0 6 6 11 12 11 7 0 12-5 13-11 8 2 18 6 22 10v-1c-3-5-14-9-23-12a12 12 0 0 1-23 0c-9 3-21 7-23 12l-1 1c5-4 15-8 23-10z"/><path style="fill:#e53d0c" d="M57 106a15 15 0 0 0 30 0l-3-1a12 12 0 0 1-23 0l-4 1z"/><path style="fill:#fff" d="M76 91s-1-3-4-3c-2 0-3 3-3 3h7z"/></g></svg>',
+            email: '',
+        );
     }
 }

--- a/app/src/Application/OAuth/AuthProviderInterface.php
+++ b/app/src/Application/OAuth/AuthProviderInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\OAuth;
+
+use Psr\Http\Message\UriInterface;
+use Spiral\Http\Request\InputManager;
+
+interface AuthProviderInterface
+{
+    public function getLoginUrl(): UriInterface;
+
+    public function isAuthenticated(): bool;
+
+    public function getUser(): ?User;
+
+    public function authenticate(InputManager $input): void;
+
+    public function getLogoutUrl(): ?UriInterface;
+
+    public function logout(): void;
+}

--- a/app/src/Application/OAuth/AuthProviderRegistryInterface.php
+++ b/app/src/Application/OAuth/AuthProviderRegistryInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\OAuth;
+
+use App\Application\Exception\AuthProviderNotFound;
+
+interface AuthProviderRegistryInterface
+{
+    /**
+     * @param class-string<AuthProviderInterface> $provider
+     */
+    public function register(string $name, string $provider): void;
+
+    /**
+     * @throws AuthProviderNotFound
+     */
+    public function get(string $name): AuthProviderInterface;
+}

--- a/app/src/Application/OAuth/AuthProviderService.php
+++ b/app/src/Application/OAuth/AuthProviderService.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\OAuth;
+
+use App\Application\Exception\AuthProviderException;
+use App\Application\Exception\AuthProviderNotFound;
+use Psr\Container\ContainerInterface;
+use Spiral\Core\Attribute\Singleton;
+
+#[Singleton]
+final class AuthProviderService implements AuthProviderRegistryInterface
+{
+    /** @var array<non-empty-string, class-string<AuthProviderInterface>> */
+    private array $providers = [];
+
+    public function __construct(
+        private readonly ContainerInterface $container,
+    ) {}
+
+    public function register(string $name, string $provider): void
+    {
+        if (!\is_subclass_of($provider, AuthProviderInterface::class)) {
+            throw new AuthProviderException(
+                \sprintf('Provider "%s" must implement AuthProviderInterface', $provider),
+            );
+        }
+
+        $this->providers[$name] = $provider;
+    }
+
+    public function get(string $name): AuthProviderInterface
+    {
+        if (!isset($this->providers[$name])) {
+            throw new AuthProviderNotFound(\sprintf('Auth provider "%s" not found', $name));
+        }
+
+        return $this->container->get($this->providers[$name]);
+    }
+}

--- a/app/src/Application/OAuth/User.php
+++ b/app/src/Application/OAuth/User.php
@@ -4,24 +4,32 @@ declare(strict_types=1);
 
 namespace App\Application\OAuth;
 
-final readonly class User
+readonly class User implements \JsonSerializable
 {
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            provider: $data['provider'],
+            username: $data['username'],
+            avatar: $data['avatar'],
+            email: $data['email'],
+        );
+    }
+
     public function __construct(
-        private array $data,
+        public ?string $provider,
+        public string $username,
+        public string $avatar,
+        public string $email,
     ) {}
 
-    public function getUsername(): string
+    public function jsonSerialize(): array
     {
-        return $this->data['nickname'] ?? 'guest';
-    }
-
-    public function getAvatar(): string
-    {
-        return $this->data['picture'];
-    }
-
-    public function getEmail(): string
-    {
-        return $this->data['email'];
+        return [
+            'provider' => $this->provider,
+            'username' => $this->username,
+            'avatar' => $this->avatar,
+            'email' => $this->email,
+        ];
     }
 }

--- a/app/src/Integration/Auth0/Auth0Bootloader.php
+++ b/app/src/Integration/Auth0/Auth0Bootloader.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Auth0;
+
+use App\Application\Bootloader\AuthBootloader;
+use App\Application\OAuth\AuthProviderRegistryInterface;
+use Auth0\SDK\Auth0;
+use Auth0\SDK\Configuration\SdkConfiguration;
+use Spiral\Boot\Bootloader\Bootloader;
+use Spiral\Boot\EnvironmentInterface;
+use Spiral\Session\SessionScope;
+
+final class Auth0Bootloader extends Bootloader
+{
+    public function defineDependencies(): array
+    {
+        return [
+            AuthBootloader::class,
+        ];
+    }
+
+    public function defineSingletons(): array
+    {
+        return [
+            AuthProvider::class => AuthProvider::class,
+        ];
+    }
+
+    public function defineBindings(): array
+    {
+        return [
+            Auth0::class => static fn(SdkConfiguration $config, SessionScope $session) => new Auth0(
+                $config->setTransientStorage(new SessionStore($session->getSection('auth0'))),
+            ),
+
+            SdkConfiguration::class => static fn(EnvironmentInterface $env) => new SdkConfiguration(
+                strategy: $env->get('AUTH_STRATEGY', SdkConfiguration::STRATEGY_REGULAR),
+                domain: $env->get('AUTH_PROVIDER_URL'),
+                clientId: $env->get('AUTH_CLIENT_ID'),
+                redirectUri: $env->get('AUTH_CALLBACK_URL'),
+                clientSecret: $env->get('AUTH_CLIENT_SECRET'),
+                scope: \explode(',', $env->get('AUTH_SCOPES', 'openid,profile,email')),
+                cookieSecret: $env->get('AUTH_COOKIE_SECRET', $env->get('ENCRYPTER_KEY') ?? 'secret'),
+            ),
+        ];
+    }
+
+    public function init(AuthProviderRegistryInterface $provider): void
+    {
+        $provider->register('auth0', AuthProvider::class);
+    }
+}

--- a/app/src/Integration/Auth0/Auth0User.php
+++ b/app/src/Integration/Auth0/Auth0User.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Auth0;
+
+use App\Application\OAuth\User;
+
+final readonly class Auth0User extends User
+{
+    public function __construct(array $user)
+    {
+        parent::__construct(
+            provider: 'auth0',
+            username: $user['nickname'],
+            avatar: $user['picture'],
+            email: $user['email'],
+        );
+    }
+}

--- a/app/src/Integration/Auth0/AuthProvider.php
+++ b/app/src/Integration/Auth0/AuthProvider.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Auth0;
+
+use App\Application\OAuth\AuthProviderInterface;
+use App\Application\OAuth\User;
+use Auth0\SDK\Auth0;
+use Nyholm\Psr7\Uri;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\UriInterface;
+use Spiral\Core\Attribute\Proxy;
+use Spiral\Http\Request\InputManager;
+
+final readonly class AuthProvider implements AuthProviderInterface
+{
+    public function __construct(
+        #[Proxy]
+        private ContainerInterface $container,
+    ) {}
+
+    public function getLoginUrl(): UriInterface
+    {
+        $auth = $this->getProvider();
+
+        if ($this->isAuthenticated()) {
+            throw new \RuntimeException('User is already authenticated');
+        }
+
+        return new Uri($auth->login());
+    }
+
+    public function isAuthenticated(): bool
+    {
+        $auth = $this->getProvider();
+        $session = $auth->getCredentials();
+
+        return null !== $session && !$session->accessTokenExpired;
+    }
+
+    public function getUser(): ?User
+    {
+        $payload = $this->getProvider()->getUser();
+
+        if (null === $payload) {
+            return null;
+        }
+
+        return new Auth0User($payload);
+    }
+
+    public function authenticate(InputManager $input): void
+    {
+        $this->getProvider()->exchange(
+            code: $input->query('code'),
+            state: $input->query('state'),
+        );
+    }
+
+    private function getProvider(): Auth0
+    {
+        return $this->container->get(Auth0::class);
+    }
+
+    public function getLogoutUrl(): ?UriInterface
+    {
+        return new Uri($this->getProvider()->authentication()->getLogoutLink());
+    }
+
+    public function logout(): void
+    {
+        $this->getProvider()->logout();
+    }
+}

--- a/app/src/Integration/Auth0/SessionStore.php
+++ b/app/src/Integration/Auth0/SessionStore.php
@@ -2,16 +2,15 @@
 
 declare(strict_types=1);
 
-namespace App\Application\OAuth;
+namespace App\Integration\Auth0;
 
 use Auth0\SDK\Contract\StoreInterface;
-use Spiral\Session\SessionScope;
+use Spiral\Session\SessionSectionInterface;
 
 final readonly class SessionStore implements StoreInterface
 {
     public function __construct(
-        private SessionScope $session,
-        private string $sessionPrefix = 'auth0',
+        private SessionSectionInterface $session,
     ) {}
 
     /**
@@ -33,7 +32,7 @@ final readonly class SessionStore implements StoreInterface
     public function delete(
         string $key,
     ): void {
-        $this->session->getSection($this->sessionPrefix)->delete($key);
+        $this->session->delete($key);
     }
 
     /**
@@ -49,7 +48,7 @@ final readonly class SessionStore implements StoreInterface
         string $key,
         $default = null,
     ) {
-        return $this->session->getSection($this->sessionPrefix)->get($key, $default);
+        return $this->session->get($key, $default);
     }
 
     /**
@@ -57,7 +56,7 @@ final readonly class SessionStore implements StoreInterface
      */
     public function purge(): void
     {
-        $this->session->getSection($this->sessionPrefix)->clear();
+        $this->session->clear();
     }
 
     /**
@@ -70,6 +69,6 @@ final readonly class SessionStore implements StoreInterface
         string $key,
         $value,
     ): void {
-        $this->session->getSection($this->sessionPrefix)->set($key, $value);
+        $this->session->set($key, $value);
     }
 }

--- a/app/src/Integration/Kinde/AuthProvider.php
+++ b/app/src/Integration/Kinde/AuthProvider.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Kinde;
+
+use App\Application\OAuth\AuthProviderInterface;
+use App\Application\OAuth\User;
+use Kinde\KindeSDK\Configuration;
+use Kinde\KindeSDK\Sdk\Utils\Utils;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\UriInterface;
+use Spiral\Core\Attribute\Proxy;
+use Spiral\Http\Request\InputManager;
+
+final readonly class AuthProvider implements AuthProviderInterface
+{
+    public function __construct(
+        #[Proxy]
+        private ContainerInterface $container,
+        private Configuration $config,
+        private SessionStorage $storage,
+    ) {}
+
+    public function getLoginUrl(): UriInterface
+    {
+        $state = Utils::randomString();
+        $this->storage->setState($state);
+
+        return $this->getProvider()->getLoginUrl();
+    }
+
+    public function isAuthenticated(): bool
+    {
+        return $this->getProvider()->isAuthenticated();
+    }
+
+    public function getUser(): ?User
+    {
+        $payload = $this->getProvider()->getUserDetails();
+
+        if (empty($payload)) {
+            return null;
+        }
+
+        return new KindeUser($payload);
+    }
+
+    public function authenticate(InputManager $input): void
+    {
+        $token = $this->getProvider()->getToken([
+            'code' => $input->query('code'),
+            'state' => $input->query('state'),
+        ]);
+
+        $this->config->setAccessToken($token->access_token);
+    }
+
+    private function getProvider(): Client
+    {
+        return $this->container->get(Client::class);
+    }
+
+    public function getLogoutUrl(): ?UriInterface
+    {
+        return $this->getProvider()->getLogoutUrl();
+    }
+
+    public function logout(): void
+    {
+        $this->getProvider()->cleanStorage();
+    }
+}

--- a/app/src/Integration/Kinde/Client.php
+++ b/app/src/Integration/Kinde/Client.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Kinde;
+
+use GuzzleHttp\ClientInterface;
+use Kinde\KindeSDK\OAuthException;
+use Kinde\KindeSDK\Sdk\Enums\GrantType;
+use Kinde\KindeSDK\Sdk\Enums\StorageEnums;
+use Kinde\KindeSDK\Sdk\Utils\Utils;
+use Nyholm\Psr7\Uri;
+use Psr\Http\Message\UriInterface;
+
+final readonly class Client
+{
+    private string $authorizationEndpoint;
+    private string $tokenEndpoint;
+    private string $logoutEndpoint;
+    private JwtTokenParser $tokenParser;
+
+    public function __construct(
+        private string $domain,
+        private ?string $redirectUri,
+        private string $clientId,
+        private string $clientSecret,
+        private ?string $logoutRedirectUri,
+        private SessionStorage $storage,
+        private ClientInterface $client,
+        private string $scopes = 'openid profile email offline',
+    ) {
+        if (!Utils::validationURL($this->domain)) {
+            throw new \InvalidArgumentException("Please provide valid domain");
+        }
+
+        if (!Utils::validationURL($this->redirectUri)) {
+            throw new \InvalidArgumentException("Please provide valid redirect_uri");
+        }
+
+        if (empty($this->clientSecret)) {
+            throw new \InvalidArgumentException("Please provide client_secret");
+        }
+
+        if (empty($this->clientId)) {
+            throw new \InvalidArgumentException("Please provide client_id");
+        }
+
+        if (empty($this->logoutRedirectUri)) {
+            throw new \InvalidArgumentException("Please provide logout_redirect_uri");
+        }
+
+        if (!Utils::validationURL($this->logoutRedirectUri)) {
+            throw new \InvalidArgumentException("Please provide valid logout_redirect_uri");
+        }
+
+        // Other endpoints
+        $this->authorizationEndpoint = $this->domain . '/oauth2/auth';
+        $this->tokenEndpoint = $this->domain . '/oauth2/token';
+        $this->logoutEndpoint = $this->domain . '/logout';
+
+        $this->tokenParser = new JwtTokenParser($this->domain . '/.well-known/jwks.json');
+    }
+
+    public function getLoginUrl(): UriInterface
+    {
+        $this->cleanStorage();
+
+        $state = Utils::randomString();
+        $this->storage->setState($state);
+
+        $searchParams = [
+            'client_id' => $this->clientId,
+            'grant_type' => GrantType::authorizationCode,
+            'redirect_uri' => $this->redirectUri,
+            'response_type' => 'code',
+            'scope' => $this->scopes,
+            'state' => $state,
+            'start_page' => 'login',
+        ];
+
+        return new Uri($this->authorizationEndpoint . '?' . \http_build_query($searchParams));
+    }
+
+    public function getLogoutUrl(): UriInterface
+    {
+        $searchParams = [
+            'redirect' => $this->logoutRedirectUri,
+        ];
+
+        return new Uri($this->logoutEndpoint . '?' . \http_build_query($searchParams));
+    }
+
+    public function cleanStorage(): void
+    {
+        $this->storage->clear();
+    }
+
+    public function getToken(array $queryParams): object
+    {
+        if ($this->isAuthenticated()) {
+            $token = $this->storage->getToken(false);
+            if (!empty($token)) {
+                return $token;
+            }
+        }
+
+        $formParams = [
+            'client_id' => $this->clientId,
+            'client_secret' => $this->clientSecret,
+            'grant_type' => 'authorization_code',
+            'redirect_uri' => $this->redirectUri,
+            'response_type' => 'code',
+        ];
+
+        $stateServer = $queryParams['state'] ?? null;
+
+        $this->checkStateAuthentication($stateServer);
+
+        $error = $queryParams['error'] ?? '';
+        if (!empty($error)) {
+            $errorDescription = $queryParams['error_description'] ?? '';
+            $msg = !empty($errorDescription) ? $errorDescription : $error;
+            throw new OAuthException($msg);
+        }
+
+        $authorizationCode = $queryParams['code'] ?? '';
+        if (empty($authorizationCode)) {
+            throw new \InvalidArgumentException('Not found code param');
+        }
+
+        $formParams['code'] = $authorizationCode;
+        $codeVerifier = $this->storage->getCodeVerifier();
+
+        if (!empty($codeVerifier)) {
+            $formParams['code_verifier'] = $codeVerifier;
+        }
+
+        return $this->fetchToken($formParams);
+    }
+
+    public function getUserDetails(): array
+    {
+        $payload = $this->tokenParser->parse(
+            $this->storage->getIdToken(),
+        );
+
+        return [
+            'id' => $payload['sub'] ?? '',
+            'given_name' => $payload['given_name'] ?? '',
+            'family_name' => $payload['family_name'] ?? '',
+            'email' => $payload['email'] ?? '',
+            'picture' => $payload['picture'] ?? '',
+        ];
+    }
+
+    private function fetchToken(array $formParams): object
+    {
+        $response = $this->client->request('POST', $this->tokenEndpoint, [
+            'form_params' => $formParams,
+            'headers' => [
+                'Kinde-SDK' => 'PHP/1.2', // current SDK version
+            ],
+        ]);
+
+        $token = $response->getBody()->getContents();
+        $this->storage->setToken($token);
+        $tokenDecode = \json_decode($token, false);
+
+        // Cleaning
+        $this->storage->removeItem(StorageEnums::CODE_VERIFIER);
+        $this->storage->removeItem(StorageEnums::STATE);
+
+        return $tokenDecode;
+    }
+
+    public function isAuthenticated(): bool
+    {
+        $accessToken = $this->tokenParser->parse($this->storage->getAccessToken() ?? '');
+        $timeExpired = empty($accessToken) ? 0 : $accessToken['exp'] ?? 0;
+        $authenticated = $timeExpired > \time();
+
+        if ($authenticated) {
+            return true;
+        }
+
+        // Using refresh token to get new access token
+        try {
+            $refreshToken = $this->storage->getRefreshToken();
+            if (!empty($refreshToken)) {
+                $formParams = [
+                    'client_id' => $this->clientId,
+                    'client_secret' => $this->clientSecret,
+                    'grant_type' => 'refresh_token',
+                    'refresh_token' => $refreshToken,
+                ];
+
+                $token = $this->fetchToken($formParams);
+                if (!empty($token) && $token->expires_in > 0) {
+                    return true;
+                }
+            }
+        } catch (\Throwable $th) {
+        }
+
+        return false;
+    }
+
+    private function checkStateAuthentication(string $stateServer): void
+    {
+        $storageOAuthState = $this->storage->getState();
+
+        if (empty($storageOAuthState) || $stateServer !== $storageOAuthState) {
+            throw new OAuthException("Authentication failed because it tries to validate state");
+        }
+    }
+}

--- a/app/src/Integration/Kinde/JwtTokenParser.php
+++ b/app/src/Integration/Kinde/JwtTokenParser.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Kinde;
+
+use Firebase\JWT\JWK;
+use Firebase\JWT\JWT;
+
+final readonly class JwtTokenParser
+{
+    public function __construct(
+        private string $jwksUrl,
+    ) {}
+
+    public function parse(string $token): ?array
+    {
+        try {
+            $jwksJson = \file_get_contents($this->jwksUrl);
+            $jwks = \json_decode($jwksJson, true);
+
+            return \json_decode(\json_encode(JWT::decode($token, JWK::parseKeySet($jwks))), true);
+        } catch (\Exception $e) {
+            return null;
+        }
+    }
+}

--- a/app/src/Integration/Kinde/KindeBootloader.php
+++ b/app/src/Integration/Kinde/KindeBootloader.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Kinde;
+
+use App\Application\Bootloader\AuthBootloader;
+use App\Application\OAuth\AuthProviderRegistryInterface;
+use Spiral\Boot\Bootloader\Bootloader;
+use Kinde\KindeSDK\KindeClientSDK;
+use Kinde\KindeSDK\Configuration;
+use Kinde\KindeSDK\Sdk\Enums\GrantType;
+use Spiral\Boot\EnvironmentInterface;
+use Spiral\Session\SessionScope;
+
+final class KindeBootloader extends Bootloader
+{
+    public function defineDependencies(): array
+    {
+        return [
+            AuthBootloader::class,
+        ];
+    }
+
+    public function defineSingletons(): array
+    {
+        return [
+            SessionStorage::class => static fn(
+                SessionScope $session,
+            ): SessionStorage => new SessionStorage(
+                section: $session->getSection('kinde'),
+            ),
+            AuthProvider::class => AuthProvider::class,
+        ];
+    }
+
+    public function defineBindings(): array
+    {
+        return [
+            Client::class => static function (
+                EnvironmentInterface $env,
+                Configuration $config,
+                SessionStorage $storage,
+            ): Client {
+                return new Client(
+                    domain: $config->getHost(),
+                    redirectUri: $env->get('AUTH_CALLBACK_URL'),
+                    clientId: $env->get('AUTH_CLIENT_ID'),
+                    clientSecret: $env->get('AUTH_CLIENT_SECRET'),
+                    logoutRedirectUri: $env->get('AUTH_LOGOUT_URL'),
+                    storage: $storage,
+                    client: new \GuzzleHttp\Client(),
+                );
+            },
+
+            Configuration::class => static fn(
+                EnvironmentInterface $env,
+            ) => (new Configuration())->setHost($env->get('AUTH_PROVIDER_URL')),
+        ];
+    }
+
+    public function init(AuthProviderRegistryInterface $provider): void
+    {
+        $provider->register('kinde', AuthProvider::class);
+    }
+}

--- a/app/src/Integration/Kinde/KindeUser.php
+++ b/app/src/Integration/Kinde/KindeUser.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Kinde;
+
+use App\Application\OAuth\User;
+
+final readonly class KindeUser extends User
+{
+    public function __construct(array $user)
+    {
+        parent::__construct(
+            provider: 'kinde',
+            username: $user['given_name'],
+            avatar: $user['picture'],
+            email: $user['email'],
+        );
+    }
+}

--- a/app/src/Integration/Kinde/SessionStorage.php
+++ b/app/src/Integration/Kinde/SessionStorage.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\Kinde;
+
+use Kinde\KindeSDK\Sdk\Enums\StorageEnums;
+use Spiral\Session\SessionSectionInterface;
+
+final class SessionStorage
+{
+    public function __construct(
+        private readonly SessionSectionInterface $section,
+    ) {}
+
+    public function getToken($associative = true): array|object|null
+    {
+        $token = $this->get(StorageEnums::TOKEN);
+
+        return empty($token) ? null : \json_decode($token, $associative);
+    }
+
+    public function setToken(string $token): void
+    {
+        $this->set(StorageEnums::TOKEN, $token);
+    }
+
+    public function getAccessToken(): ?string
+    {
+        $token = $this->getToken();
+        return empty($token) ? null : $token['access_token'];
+    }
+
+    public function getIdToken(): ?string
+    {
+        $token = $this->getToken();
+        return empty($token) ? null : $token['id_token'];
+    }
+
+    public function getRefreshToken(): ?string
+    {
+        $token = $this->getToken();
+        return empty($token) ? null : $token['refresh_token'];
+    }
+
+    public function getState(): ?string
+    {
+        return $this->get(StorageEnums::STATE);
+    }
+
+    public function setState(string $newState): void
+    {
+        $this->set(StorageEnums::STATE, $newState);
+    }
+
+    public function getCodeVerifier(): ?string
+    {
+        return $this->get(StorageEnums::CODE_VERIFIER);
+    }
+
+    public function clear(): void
+    {
+        $this->purge();
+    }
+
+    public function removeItem(string $key): void
+    {
+        $this->delete($key);
+    }
+
+    private function delete(string $key): void
+    {
+        $this->section->delete($key);
+    }
+
+    private function get(string $key, mixed $default = null): mixed
+    {
+        return $this->section->get($key, $default);
+    }
+
+    private function purge(): void
+    {
+        $this->section->clear();
+    }
+
+    private function set(string $key, mixed $value): void
+    {
+        $this->section->set($key, $value);
+    }
+}

--- a/app/src/Interfaces/Http/Controller/Auth/CallbackAction.php
+++ b/app/src/Interfaces/Http/Controller/Auth/CallbackAction.php
@@ -5,30 +5,27 @@ declare(strict_types=1);
 namespace App\Interfaces\Http\Controller\Auth;
 
 use App\Application\Auth\SuccessRedirect;
-use Auth0\SDK\Auth0;
+use App\Application\OAuth\AuthProviderInterface;
 use Psr\Http\Message\ResponseInterface;
 use Spiral\Auth\AuthScope;
 use Spiral\Auth\TokenStorageInterface;
 use Spiral\Http\Request\InputManager;
 use Spiral\Router\Annotation\Route;
 
-final class CallbackAction
+final readonly class CallbackAction
 {
     #[Route(route: 'auth/sso/callback', methods: ['GET'], group: 'guest')]
     public function __invoke(
-        Auth0 $auth,
+        AuthProviderInterface $auth,
         InputManager $input,
         AuthScope $authScope,
         TokenStorageInterface $tokens,
         SuccessRedirect $successRedirect,
     ): ResponseInterface {
-        $auth->exchange(
-            code: $input->query('code'),
-            state: $input->query('state'),
-        );
+        $auth->authenticate($input);
 
         $authScope->start(
-            $token = $tokens->create($auth->getUser()),
+            $token = $tokens->create($auth->getUser()->jsonSerialize()),
         );
 
         return $successRedirect->makeResponse($token->getID());

--- a/app/src/Interfaces/Http/Controller/Auth/LoginAction.php
+++ b/app/src/Interfaces/Http/Controller/Auth/LoginAction.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace App\Interfaces\Http\Controller\Auth;
 
 use App\Application\Auth\SuccessRedirect;
-use Auth0\SDK\Auth0;
+use App\Application\OAuth\AuthProviderInterface;
 use Psr\Http\Message\ResponseInterface;
 use Spiral\Auth\AuthScope;
 use Spiral\Auth\TokenStorageInterface;
 use Spiral\Http\ResponseWrapper;
 use Spiral\Router\Annotation\Route;
+use Spiral\Session\SessionScope;
 
 final readonly class LoginAction
 {
@@ -20,19 +21,20 @@ final readonly class LoginAction
 
     #[Route(route: 'auth/sso/login', methods: ['GET'], group: 'guest')]
     public function __invoke(
-        Auth0 $auth,
+        AuthProviderInterface $auth,
         AuthScope $authScope,
         TokenStorageInterface $tokens,
         SuccessRedirect $successRedirect,
+        SessionScope $session,
     ): ResponseInterface {
-        $session = $auth->getCredentials();
+        if (!$auth->isAuthenticated()) {
+            $url = $auth->getLoginUrl();
 
-        if (null === $session || $session->accessTokenExpired) {
-            return $this->response->redirect($auth->login());
+            return $this->response->redirect($url);
         }
 
         $authScope->start(
-            $token = $tokens->create($auth->getUser()),
+            $token = $tokens->create($auth->getUser()->jsonSerialize()),
         );
 
         return $successRedirect->makeResponse($token->getID());

--- a/app/src/Interfaces/Http/Controller/Auth/LogoutAction.php
+++ b/app/src/Interfaces/Http/Controller/Auth/LogoutAction.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interfaces\Http\Controller\Auth;
+
+use App\Application\OAuth\AuthProviderInterface;
+use Psr\Http\Message\ResponseInterface;
+use Spiral\Http\ResponseWrapper;
+use Spiral\Router\Annotation\Route;
+
+final readonly class LogoutAction
+{
+    public function __construct(
+        private ResponseWrapper $response,
+    ) {}
+
+    #[Route(route: 'auth/sso/logout', methods: ['GET'], group: 'guest')]
+    public function __invoke(
+        AuthProviderInterface $auth,
+    ): ResponseInterface {
+
+        $auth->logout();
+
+        return $this->response->create(200);
+    }
+}

--- a/app/src/Interfaces/Http/Controller/Auth/MeAction.php
+++ b/app/src/Interfaces/Http/Controller/Auth/MeAction.php
@@ -7,19 +7,21 @@ namespace App\Interfaces\Http\Controller\Auth;
 use App\Application\HTTP\Response\ResourceInterface;
 use App\Application\HTTP\Response\UserResource;
 use App\Application\OAuth\ActorProvider;
+use App\Application\OAuth\AuthProviderInterface;
 use App\Application\OAuth\User;
 use Spiral\Auth\AuthScope;
 use Spiral\Router\Annotation\Route;
 
-final class MeAction
+final readonly class MeAction
 {
     #[Route(route: 'me', methods: ['GET'], group: 'api')]
     public function __invoke(
         AuthScope $authScope,
+        AuthProviderInterface $auth,
     ): ResourceInterface {
         /** @var User $actor */
-        $actor = $authScope->getActor() ?? new User(ActorProvider::getGuestPayload());
+        $actor = $authScope->getActor() ?? ActorProvider::getGuestPayload();
 
-        return new UserResource($actor);
+        return new UserResource($actor, $auth->getLogoutUrl());
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "doctrine/collections": "^1.8",
         "firebase/php-jwt": "^6.10",
         "guzzlehttp/guzzle": "^7.8",
+        "kinde-oss/kinde-auth-php": "^1.2",
         "mongodb/mongodb": "^1.18",
         "nesbot/carbon": "^2.64",
         "php-http/message": "^1.11",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f9124b8d008feb70dd0ae125a4166c87",
+    "content-hash": "b0fdf1e68a06942b967cced5b7f383f6",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -107,25 +107,25 @@
         },
         {
             "name": "brick/math",
-            "version": "0.11.0",
+            "version": "0.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/brick/math.git",
-                "reference": "0ad82ce168c82ba30d1c01ec86116ab52f589478"
+                "reference": "f510c0a40911935b77b86859eb5223d58d660df1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brick/math/zipball/0ad82ce168c82ba30d1c01ec86116ab52f589478",
-                "reference": "0ad82ce168c82ba30d1c01ec86116ab52f589478",
+                "url": "https://api.github.com/repos/brick/math/zipball/f510c0a40911935b77b86859eb5223d58d660df1",
+                "reference": "f510c0a40911935b77b86859eb5223d58d660df1",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.0"
+                "php": "^8.1"
             },
             "require-dev": {
                 "php-coveralls/php-coveralls": "^2.2",
-                "phpunit/phpunit": "^9.0",
-                "vimeo/psalm": "5.0.0"
+                "phpunit/phpunit": "^10.1",
+                "vimeo/psalm": "5.16.0"
             },
             "type": "library",
             "autoload": {
@@ -145,12 +145,17 @@
                 "arithmetic",
                 "bigdecimal",
                 "bignum",
+                "bignumber",
                 "brick",
-                "math"
+                "decimal",
+                "integer",
+                "math",
+                "mathematics",
+                "rational"
             ],
             "support": {
                 "issues": "https://github.com/brick/math/issues",
-                "source": "https://github.com/brick/math/tree/0.11.0"
+                "source": "https://github.com/brick/math/tree/0.12.1"
             },
             "funding": [
                 {
@@ -158,7 +163,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-15T23:15:59+00:00"
+            "time": "2023-11-29T23:19:16+00:00"
         },
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -2060,6 +2065,64 @@
                 }
             ],
             "time": "2023-12-03T20:05:35+00:00"
+        },
+        {
+            "name": "kinde-oss/kinde-auth-php",
+            "version": "1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kinde-oss/kinde-php-sdk.git",
+                "reference": "c8b57ec2a3d56cf3423d226bc695b9e94ddfbe82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kinde-oss/kinde-php-sdk/zipball/c8b57ec2a3d56cf3423d226bc695b9e94ddfbe82",
+                "reference": "c8b57ec2a3d56cf3423d226bc695b9e94ddfbe82",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "firebase/php-jwt": "^6.10",
+                "guzzlehttp/guzzle": "^7.3",
+                "guzzlehttp/psr7": "^1.7 || ^2.0",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.5",
+                "phpunit/phpunit": "^8.0 || ^9.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Kinde\\KindeSDK\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kinde Engineering",
+                    "homepage": "https://kinde.com"
+                }
+            ],
+            "description": "Kinde PHP SDK for authentication",
+            "homepage": "https://kinde.com",
+            "keywords": [
+                "Authentication",
+                "auth",
+                "kinde",
+                "php",
+                "sdk"
+            ],
+            "support": {
+                "issues": "https://github.com/kinde-oss/kinde-php-sdk/issues",
+                "source": "https://github.com/kinde-oss/kinde-php-sdk/tree/v1.2.3"
+            },
+            "time": "2024-03-19T16:03:16+00:00"
         },
         {
             "name": "league/event",
@@ -4861,20 +4924,20 @@
         },
         {
             "name": "ramsey/uuid",
-            "version": "4.7.5",
+            "version": "4.7.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
-                "reference": "5f0df49ae5ad6efb7afa69e6bfab4e5b1e080d8e"
+                "reference": "91039bc1faa45ba123c4328958e620d382ec7088"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/5f0df49ae5ad6efb7afa69e6bfab4e5b1e080d8e",
-                "reference": "5f0df49ae5ad6efb7afa69e6bfab4e5b1e080d8e",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/91039bc1faa45ba123c4328958e620d382ec7088",
+                "reference": "91039bc1faa45ba123c4328958e620d382ec7088",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "^0.8.8 || ^0.9 || ^0.10 || ^0.11",
+                "brick/math": "^0.8.8 || ^0.9 || ^0.10 || ^0.11 || ^0.12",
                 "ext-json": "*",
                 "php": "^8.0",
                 "ramsey/collection": "^1.2 || ^2.0"
@@ -4937,7 +5000,7 @@
             ],
             "support": {
                 "issues": "https://github.com/ramsey/uuid/issues",
-                "source": "https://github.com/ramsey/uuid/tree/4.7.5"
+                "source": "https://github.com/ramsey/uuid/tree/4.7.6"
             },
             "funding": [
                 {
@@ -4949,7 +5012,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-11-08T05:53:05+00:00"
+            "time": "2024-04-27T21:32:50+00:00"
         },
         {
             "name": "roadrunner-php/app-logger",
@@ -6870,16 +6933,16 @@
         },
         {
             "name": "symfony/clock",
-            "version": "v7.0.5",
+            "version": "v7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/clock.git",
-                "reference": "8b9d08887353d627d5f6c3bf3373b398b49051c2"
+                "reference": "2008671acb4a30b01c453de193cf9c80549ebda6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/clock/zipball/8b9d08887353d627d5f6c3bf3373b398b49051c2",
-                "reference": "8b9d08887353d627d5f6c3bf3373b398b49051c2",
+                "url": "https://api.github.com/repos/symfony/clock/zipball/2008671acb4a30b01c453de193cf9c80549ebda6",
+                "reference": "2008671acb4a30b01c453de193cf9c80549ebda6",
                 "shasum": ""
             },
             "require": {
@@ -6924,7 +6987,7 @@
                 "time"
             ],
             "support": {
-                "source": "https://github.com/symfony/clock/tree/v7.0.5"
+                "source": "https://github.com/symfony/clock/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -6940,20 +7003,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-02T12:46:12+00:00"
+            "time": "2024-04-18T09:29:19+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v7.0.6",
+            "version": "v7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "fde915cd8e7eb99b3d531d3d5c09531429c3f9e5"
+                "reference": "c981e0e9380ce9f146416bde3150c79197ce9986"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/fde915cd8e7eb99b3d531d3d5c09531429c3f9e5",
-                "reference": "fde915cd8e7eb99b3d531d3d5c09531429c3f9e5",
+                "url": "https://api.github.com/repos/symfony/console/zipball/c981e0e9380ce9f146416bde3150c79197ce9986",
+                "reference": "c981e0e9380ce9f146416bde3150c79197ce9986",
                 "shasum": ""
             },
             "require": {
@@ -7017,7 +7080,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.0.6"
+                "source": "https://github.com/symfony/console/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -7033,7 +7096,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-01T11:04:53+00:00"
+            "time": "2024-04-18T09:29:19+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -7104,16 +7167,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v7.0.3",
+            "version": "v7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "834c28d533dd0636f910909d01b9ff45cc094b5e"
+                "reference": "db2a7fab994d67d92356bb39c367db115d9d30f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/834c28d533dd0636f910909d01b9ff45cc094b5e",
-                "reference": "834c28d533dd0636f910909d01b9ff45cc094b5e",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/db2a7fab994d67d92356bb39c367db115d9d30f9",
+                "reference": "db2a7fab994d67d92356bb39c367db115d9d30f9",
                 "shasum": ""
             },
             "require": {
@@ -7164,7 +7227,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v7.0.3"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -7180,7 +7243,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-23T15:02:46+00:00"
+            "time": "2024-04-18T09:29:19+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -7260,16 +7323,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v7.0.0",
+            "version": "v7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "6e5688d69f7cfc4ed4a511e96007e06c2d34ce56"
+                "reference": "4d58f0f4fe95a30d7b538d71197135483560b97c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/6e5688d69f7cfc4ed4a511e96007e06c2d34ce56",
-                "reference": "6e5688d69f7cfc4ed4a511e96007e06c2d34ce56",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/4d58f0f4fe95a30d7b538d71197135483560b97c",
+                "reference": "4d58f0f4fe95a30d7b538d71197135483560b97c",
                 "shasum": ""
             },
             "require": {
@@ -7304,7 +7367,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v7.0.0"
+                "source": "https://github.com/symfony/finder/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -7320,20 +7383,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-31T17:59:56+00:00"
+            "time": "2024-04-28T11:44:19+00:00"
         },
         {
             "name": "symfony/mailer",
-            "version": "v7.0.6",
+            "version": "v7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "eb0c3187c7ddfde12d8aa0e1fa5fb29e730a41e0"
+                "reference": "4ff41a7c7998a88cfdc31b5841ef64d9246fc56a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/eb0c3187c7ddfde12d8aa0e1fa5fb29e730a41e0",
-                "reference": "eb0c3187c7ddfde12d8aa0e1fa5fb29e730a41e0",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/4ff41a7c7998a88cfdc31b5841ef64d9246fc56a",
+                "reference": "4ff41a7c7998a88cfdc31b5841ef64d9246fc56a",
                 "shasum": ""
             },
             "require": {
@@ -7384,7 +7447,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/v7.0.6"
+                "source": "https://github.com/symfony/mailer/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -7400,20 +7463,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-28T09:20:36+00:00"
+            "time": "2024-04-18T09:29:19+00:00"
         },
         {
             "name": "symfony/messenger",
-            "version": "v6.4.6",
+            "version": "v6.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/messenger.git",
-                "reference": "4b7f073d341f6d0b431a1c643b40aa21506ca820"
+                "reference": "5b2a0b391a670727b0f511452d0bf646235cb388"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/messenger/zipball/4b7f073d341f6d0b431a1c643b40aa21506ca820",
-                "reference": "4b7f073d341f6d0b431a1c643b40aa21506ca820",
+                "url": "https://api.github.com/repos/symfony/messenger/zipball/5b2a0b391a670727b0f511452d0bf646235cb388",
+                "reference": "5b2a0b391a670727b0f511452d0bf646235cb388",
                 "shasum": ""
             },
             "require": {
@@ -7471,7 +7534,7 @@
             "description": "Helps applications send and receive messages to/from other applications or via message queues",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/messenger/tree/v6.4.6"
+                "source": "https://github.com/symfony/messenger/tree/v6.4.7"
             },
             "funding": [
                 {
@@ -7487,20 +7550,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-19T11:56:30+00:00"
+            "time": "2024-04-18T09:22:46+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v6.4.6",
+            "version": "v6.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "14762b86918823cb42e3558cdcca62e58b5227fe"
+                "reference": "decadcf3865918ecfcbfa90968553994ce935a5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/14762b86918823cb42e3558cdcca62e58b5227fe",
-                "reference": "14762b86918823cb42e3558cdcca62e58b5227fe",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/decadcf3865918ecfcbfa90968553994ce935a5e",
+                "reference": "decadcf3865918ecfcbfa90968553994ce935a5e",
                 "shasum": ""
             },
             "require": {
@@ -7556,7 +7619,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v6.4.6"
+                "source": "https://github.com/symfony/mime/tree/v6.4.7"
             },
             "funding": [
                 {
@@ -7572,7 +7635,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-21T19:36:20+00:00"
+            "time": "2024-04-18T09:22:46+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -8364,16 +8427,16 @@
         },
         {
             "name": "symfony/property-access",
-            "version": "v7.0.6",
+            "version": "v7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-access.git",
-                "reference": "1c268ba954ccc5e78cf035b391abb67759e24423"
+                "reference": "8661b861480d2807eb2789ff99d034c0c71ab955"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/property-access/zipball/1c268ba954ccc5e78cf035b391abb67759e24423",
-                "reference": "1c268ba954ccc5e78cf035b391abb67759e24423",
+                "url": "https://api.github.com/repos/symfony/property-access/zipball/8661b861480d2807eb2789ff99d034c0c71ab955",
+                "reference": "8661b861480d2807eb2789ff99d034c0c71ab955",
                 "shasum": ""
             },
             "require": {
@@ -8420,7 +8483,7 @@
                 "reflection"
             ],
             "support": {
-                "source": "https://github.com/symfony/property-access/tree/v7.0.6"
+                "source": "https://github.com/symfony/property-access/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -8436,20 +8499,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-19T11:57:22+00:00"
+            "time": "2024-04-18T09:29:19+00:00"
         },
         {
             "name": "symfony/property-info",
-            "version": "v7.0.6",
+            "version": "v7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-info.git",
-                "reference": "b8844ddce7d53f78b57ec9be59da80fceddf3167"
+                "reference": "f0bdb46e19ab308527b324b7ec36161f6880a532"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/property-info/zipball/b8844ddce7d53f78b57ec9be59da80fceddf3167",
-                "reference": "b8844ddce7d53f78b57ec9be59da80fceddf3167",
+                "url": "https://api.github.com/repos/symfony/property-info/zipball/f0bdb46e19ab308527b324b7ec36161f6880a532",
+                "reference": "f0bdb46e19ab308527b324b7ec36161f6880a532",
                 "shasum": ""
             },
             "require": {
@@ -8503,7 +8566,7 @@
                 "validator"
             ],
             "support": {
-                "source": "https://github.com/symfony/property-info/tree/v7.0.6"
+                "source": "https://github.com/symfony/property-info/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -8519,20 +8582,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-28T09:20:36+00:00"
+            "time": "2024-04-28T11:44:19+00:00"
         },
         {
             "name": "symfony/serializer",
-            "version": "v7.0.6",
+            "version": "v7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
-                "reference": "dbdc0c04c28ac53de1fa35f92fca26e9b1345d98"
+                "reference": "08f0c517acf4b12dfc0d3963cd12f7b8023aea31"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/serializer/zipball/dbdc0c04c28ac53de1fa35f92fca26e9b1345d98",
-                "reference": "dbdc0c04c28ac53de1fa35f92fca26e9b1345d98",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/08f0c517acf4b12dfc0d3963cd12f7b8023aea31",
+                "reference": "08f0c517acf4b12dfc0d3963cd12f7b8023aea31",
                 "shasum": ""
             },
             "require": {
@@ -8598,7 +8661,7 @@
             "description": "Handles serializing and deserializing data structures, including object graphs, into array structures or other formats like XML and JSON.",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/serializer/tree/v7.0.6"
+                "source": "https://github.com/symfony/serializer/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -8614,7 +8677,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-28T09:20:36+00:00"
+            "time": "2024-04-28T11:44:19+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -8700,16 +8763,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v7.0.4",
+            "version": "v7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "f5832521b998b0bec40bee688ad5de98d4cf111b"
+                "reference": "e405b5424dc2528e02e31ba26b83a79fd4eb8f63"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/f5832521b998b0bec40bee688ad5de98d4cf111b",
-                "reference": "f5832521b998b0bec40bee688ad5de98d4cf111b",
+                "url": "https://api.github.com/repos/symfony/string/zipball/e405b5424dc2528e02e31ba26b83a79fd4eb8f63",
+                "reference": "e405b5424dc2528e02e31ba26b83a79fd4eb8f63",
                 "shasum": ""
             },
             "require": {
@@ -8766,7 +8829,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.0.4"
+                "source": "https://github.com/symfony/string/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -8782,20 +8845,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-02-01T13:17:36+00:00"
+            "time": "2024-04-18T09:29:19+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v6.4.4",
+            "version": "v6.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "bce6a5a78e94566641b2594d17e48b0da3184a8e"
+                "reference": "7495687c58bfd88b7883823747b0656d90679123"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/bce6a5a78e94566641b2594d17e48b0da3184a8e",
-                "reference": "bce6a5a78e94566641b2594d17e48b0da3184a8e",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/7495687c58bfd88b7883823747b0656d90679123",
+                "reference": "7495687c58bfd88b7883823747b0656d90679123",
                 "shasum": ""
             },
             "require": {
@@ -8861,7 +8924,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v6.4.4"
+                "source": "https://github.com/symfony/translation/tree/v6.4.7"
             },
             "funding": [
                 {
@@ -8877,7 +8940,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-02-20T13:16:58+00:00"
+            "time": "2024-04-18T09:22:46+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -8959,16 +9022,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v6.4.6",
+            "version": "v6.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "95bd2706a97fb875185b51ecaa6112ec184233d4"
+                "reference": "7a9cd977cd1c5fed3694bee52990866432af07d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/95bd2706a97fb875185b51ecaa6112ec184233d4",
-                "reference": "95bd2706a97fb875185b51ecaa6112ec184233d4",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/7a9cd977cd1c5fed3694bee52990866432af07d7",
+                "reference": "7a9cd977cd1c5fed3694bee52990866432af07d7",
                 "shasum": ""
             },
             "require": {
@@ -9024,7 +9087,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v6.4.6"
+                "source": "https://github.com/symfony/var-dumper/tree/v6.4.7"
             },
             "funding": [
                 {
@@ -9040,20 +9103,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-19T11:56:30+00:00"
+            "time": "2024-04-18T09:22:46+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v7.0.3",
+            "version": "v7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "2d4fca631c00700597e9442a0b2451ce234513d3"
+                "reference": "0d3916ae69ea28b59d94b60c4f2b50f4e25adb5c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/2d4fca631c00700597e9442a0b2451ce234513d3",
-                "reference": "2d4fca631c00700597e9442a0b2451ce234513d3",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/0d3916ae69ea28b59d94b60c4f2b50f4e25adb5c",
+                "reference": "0d3916ae69ea28b59d94b60c4f2b50f4e25adb5c",
                 "shasum": ""
             },
             "require": {
@@ -9095,7 +9158,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.0.3"
+                "source": "https://github.com/symfony/yaml/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -9111,7 +9174,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-23T15:02:46+00:00"
+            "time": "2024-04-28T11:44:19+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
@@ -9317,16 +9380,16 @@
         },
         {
             "name": "zbateson/mail-mime-parser",
-            "version": "2.4.0",
+            "version": "2.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zbateson/mail-mime-parser.git",
-                "reference": "20b3e48eb799537683780bc8782fbbe9bc25934a"
+                "reference": "ff49e02f6489b38f7cc3d1bd3971adc0f872569c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zbateson/mail-mime-parser/zipball/20b3e48eb799537683780bc8782fbbe9bc25934a",
-                "reference": "20b3e48eb799537683780bc8782fbbe9bc25934a",
+                "url": "https://api.github.com/repos/zbateson/mail-mime-parser/zipball/ff49e02f6489b38f7cc3d1bd3971adc0f872569c",
+                "reference": "ff49e02f6489b38f7cc3d1bd3971adc0f872569c",
                 "shasum": ""
             },
             "require": {
@@ -9388,7 +9451,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-14T22:58:03+00:00"
+            "time": "2024-04-28T00:58:54+00:00"
         },
         {
             "name": "zbateson/mb-wrapper",
@@ -12469,16 +12532,16 @@
         },
         {
             "name": "spatie/array-to-xml",
-            "version": "3.2.3",
+            "version": "3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/array-to-xml.git",
-                "reference": "c95fd4db94ec199f798d4b5b4a81757bd20d88ab"
+                "reference": "f56b220fe2db1ade4c88098d83413ebdfc3bf876"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/c95fd4db94ec199f798d4b5b4a81757bd20d88ab",
-                "reference": "c95fd4db94ec199f798d4b5b4a81757bd20d88ab",
+                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/f56b220fe2db1ade4c88098d83413ebdfc3bf876",
+                "reference": "f56b220fe2db1ade4c88098d83413ebdfc3bf876",
                 "shasum": ""
             },
             "require": {
@@ -12491,6 +12554,11 @@
                 "spatie/pest-plugin-snapshots": "^1.1"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Spatie\\ArrayToXml\\": "src"
@@ -12516,7 +12584,7 @@
                 "xml"
             ],
             "support": {
-                "source": "https://github.com/spatie/array-to-xml/tree/3.2.3"
+                "source": "https://github.com/spatie/array-to-xml/tree/3.3.0"
             },
             "funding": [
                 {
@@ -12528,7 +12596,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-02-07T10:39:02+00:00"
+            "time": "2024-05-01T10:20:27+00:00"
         },
         {
             "name": "spatie/backtrace",
@@ -12985,22 +13053,23 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v7.0.6",
+            "version": "v7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "408105dff4c104454100730bdfd1a9cdd993f04d"
+                "reference": "cc168be6fbdcdf3401f50ae863ee3818ed4338f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/408105dff4c104454100730bdfd1a9cdd993f04d",
-                "reference": "408105dff4c104454100730bdfd1a9cdd993f04d",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/cc168be6fbdcdf3401f50ae863ee3818ed4338f5",
+                "reference": "cc168be6fbdcdf3401f50ae863ee3818ed4338f5",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2",
                 "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-mbstring": "~1.8"
+                "symfony/polyfill-mbstring": "~1.8",
+                "symfony/process": "^6.4|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -13028,7 +13097,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.0.6"
+                "source": "https://github.com/symfony/filesystem/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -13044,7 +13113,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-21T19:37:36+00:00"
+            "time": "2024-04-18T09:29:19+00:00"
         },
         {
             "name": "symfony/http-client",
@@ -13218,16 +13287,16 @@
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v7.0.0",
+            "version": "v7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "700ff4096e346f54cb628ea650767c8130f1001f"
+                "reference": "23cc173858776ad451e31f053b1c9f47840b2cfa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/700ff4096e346f54cb628ea650767c8130f1001f",
-                "reference": "700ff4096e346f54cb628ea650767c8130f1001f",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/23cc173858776ad451e31f053b1c9f47840b2cfa",
+                "reference": "23cc173858776ad451e31f053b1c9f47840b2cfa",
                 "shasum": ""
             },
             "require": {
@@ -13265,7 +13334,7 @@
                 "options"
             ],
             "support": {
-                "source": "https://github.com/symfony/options-resolver/tree/v7.0.0"
+                "source": "https://github.com/symfony/options-resolver/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -13281,20 +13350,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-08T10:20:21+00:00"
+            "time": "2024-04-18T09:29:19+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v7.0.4",
+            "version": "v7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "0e7727191c3b71ebec6d529fa0e50a01ca5679e9"
+                "reference": "3839e56b94dd1dbd13235d27504e66baf23faba0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/0e7727191c3b71ebec6d529fa0e50a01ca5679e9",
-                "reference": "0e7727191c3b71ebec6d529fa0e50a01ca5679e9",
+                "url": "https://api.github.com/repos/symfony/process/zipball/3839e56b94dd1dbd13235d27504e66baf23faba0",
+                "reference": "3839e56b94dd1dbd13235d27504e66baf23faba0",
                 "shasum": ""
             },
             "require": {
@@ -13326,7 +13395,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.0.4"
+                "source": "https://github.com/symfony/process/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -13342,20 +13411,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-02-22T20:27:20+00:00"
+            "time": "2024-04-18T09:29:19+00:00"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v7.0.3",
+            "version": "v7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "983900d6fddf2b0cbaacacbbad07610854bd8112"
+                "reference": "41a7a24aa1dc82adf46a06bc292d1923acfe6b84"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/983900d6fddf2b0cbaacacbbad07610854bd8112",
-                "reference": "983900d6fddf2b0cbaacacbbad07610854bd8112",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/41a7a24aa1dc82adf46a06bc292d1923acfe6b84",
+                "reference": "41a7a24aa1dc82adf46a06bc292d1923acfe6b84",
                 "shasum": ""
             },
             "require": {
@@ -13388,7 +13457,7 @@
             "description": "Provides a way to profile code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/stopwatch/tree/v7.0.3"
+                "source": "https://github.com/symfony/stopwatch/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -13404,7 +13473,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-23T15:02:46+00:00"
+            "time": "2024-04-18T09:29:19+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/tests/Feature/Interfaces/Http/Auth/SSO/CallbackActionTest.php
+++ b/tests/Feature/Interfaces/Http/Auth/SSO/CallbackActionTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Interfaces\Http\Auth\SSO;
+
+use App\Application\OAuth\AuthProviderInterface;
+use App\Application\OAuth\User;
+use Tests\App\Http\ResponseAssertions;
+use Tests\Feature\Interfaces\Http\ControllerTestCase;
+
+final class CallbackActionTest extends ControllerTestCase
+{
+    private \Mockery\MockInterface|AuthProviderInterface $auth;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->auth = $this->mockContainer(AuthProviderInterface::class);
+    }
+
+    public function testCallback(): void
+    {
+        $this->auth
+            ->shouldReceive('authenticate')
+            ->once()
+            ->with(\Mockery::type(\Spiral\Http\Request\InputManager::class));
+
+        $this->auth->shouldReceive('getUser')
+            ->once()
+            ->andReturn(
+                $user = new User(
+                    provider: 'fake',
+                    username: 'johndoe',
+                    avatar: 'https://example.com/avatar.jpg',
+                    email: 'johndoe@site.com',
+                ),
+            );
+
+        /** @var ResponseAssertions $response */
+        $response = $this->http->get('/auth/sso/callback', [
+            'code' => 'code_123',
+            'state' => 'state_123',
+        ]);
+
+        $response->assertRedirect(uri: static fn(string $location) => \str_starts_with($location, '/#/login?token='));
+    }
+}

--- a/tests/Feature/Interfaces/Http/Auth/SSO/LoginActionTest.php
+++ b/tests/Feature/Interfaces/Http/Auth/SSO/LoginActionTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Interfaces\Http\Auth\SSO;
+
+use App\Application\OAuth\AuthProviderInterface;
+use App\Application\OAuth\User;
+use Nyholm\Psr7\Uri;
+use Tests\App\Http\ResponseAssertions;
+use Tests\Feature\Interfaces\Http\ControllerTestCase;
+
+final class LoginActionTest extends ControllerTestCase
+{
+    private \Mockery\MockInterface|AuthProviderInterface $auth;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->auth = $this->mockContainer(AuthProviderInterface::class);
+    }
+
+    public function testLoginUnauthenticated(): void
+    {
+        $this->auth->shouldReceive('isAuthenticated')
+            ->once()
+            ->andReturnFalse();
+
+        $this->auth->shouldReceive('getLoginUrl')
+            ->once()
+            ->andReturn($uri = new Uri('https://example.com/login'));
+
+        /** @var ResponseAssertions $response */
+        $response = $this->http->get('/auth/sso/login');
+
+        $response->assertRedirect(uri: (string) $uri);
+    }
+
+    public function testLoginAuthenticated(): void
+    {
+        $this->auth->shouldReceive('isAuthenticated')
+            ->once()
+            ->andReturnTrue();
+
+        $this->auth->shouldReceive('getUser')
+            ->once()
+            ->andReturn(
+                $user = new User(
+                    provider: 'fake',
+                    username: 'johndoe',
+                    avatar: 'https://example.com/avatar.jpg',
+                    email: 'johndoe@site.com',
+                ),
+            );
+
+        /** @var ResponseAssertions $response */
+        $response = $this->http->get('/auth/sso/login');
+
+        $response->assertRedirect(uri: static fn(string $location) => \str_starts_with($location, '/#/login?token='));
+    }
+}

--- a/tests/Feature/Interfaces/Http/Auth/SSO/LogoutActionTest.php
+++ b/tests/Feature/Interfaces/Http/Auth/SSO/LogoutActionTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Interfaces\Http\Auth\SSO;
+
+use App\Application\OAuth\AuthProviderInterface;
+use Tests\Feature\Interfaces\Http\ControllerTestCase;
+
+final class LogoutActionTest extends ControllerTestCase
+{
+    private \Mockery\MockInterface|AuthProviderInterface $auth;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->auth = $this->mockContainer(AuthProviderInterface::class);
+    }
+
+    public function testLogout(): void
+    {
+        $this->auth
+            ->shouldReceive('logout')
+            ->once();
+
+        $response = $this->http->get('/auth/sso/logout');
+
+        $response->assertStatus(200);
+    }
+}

--- a/tests/Feature/Interfaces/Http/Auth/SSO/MeActionTest.php
+++ b/tests/Feature/Interfaces/Http/Auth/SSO/MeActionTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Interfaces\Http\Auth\SSO;
+
+use App\Application\HTTP\Response\UserResource;
+use App\Application\OAuth\ActorProvider;
+use App\Application\OAuth\AuthProviderInterface;
+use App\Application\OAuth\User;
+use Nyholm\Psr7\Uri;
+use Tests\App\Http\ResponseAssertions;
+use Tests\Feature\Interfaces\Http\ControllerTestCase;
+
+final class MeActionTest extends ControllerTestCase
+{
+    private \Mockery\MockInterface|AuthProviderInterface $auth;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->auth = $this->mockContainer(AuthProviderInterface::class);
+    }
+
+    public function testShowProfile(): void
+    {
+        $this->auth
+            ->shouldReceive('getLogoutUrl')
+            ->once()
+            ->andReturn($uri = new Uri('https://example.com/logout'));
+
+        $user = new User(
+            provider: 'provider',
+            username: 'user',
+            avatar: 'https://example.com/avatar',
+            email: 'user',
+        );
+
+        /** @var ResponseAssertions $response */
+        $response = $this->http->authenticate($user)->get('/api/me');
+
+        $response->assertResource(
+            new UserResource($user, $uri),
+        );
+    }
+
+    public function testGuestProfile(): void
+    {
+        $this->auth
+            ->shouldReceive('getLogoutUrl')
+            ->once()
+            ->andReturn($uri = new Uri('https://example.com/logout'));
+
+        /** @var ResponseAssertions $response */
+        $response = $this->http->get('/api/me');
+
+        $response->assertResource(
+            new UserResource(ActorProvider::getGuestPayload(), $uri),
+        );
+    }
+}

--- a/tests/Feature/Interfaces/Http/ControllerTestCase.php
+++ b/tests/Feature/Interfaces/Http/ControllerTestCase.php
@@ -15,6 +15,6 @@ abstract class ControllerTestCase extends DatabaseTestCase
     {
         parent::setUp();
 
-        $this->http = new HttpFaker($this->fakeHttp());
+        $this->http = new HttpFaker($this->fakeHttp(), $this);
     }
 }

--- a/tests/Feature/Interfaces/Http/Ray/RayTestCase.php
+++ b/tests/Feature/Interfaces/Http/Ray/RayTestCase.php
@@ -17,7 +17,7 @@ abstract class RayTestCase extends ControllerTestCase
     {
         parent::setUp();
 
-        $this->client = new FakeClient(new HttpFaker($this->fakeHttp()));
+        $this->client = new FakeClient(new HttpFaker($this->fakeHttp(), $this));
     }
 
     protected function buildRay(): Ray


### PR DESCRIPTION
This PR adds support for Kindle authentication and refactors the authentication mechanism to make it easier to add new providers in the future. Additionally, it includes thorough tests for authentication.

**Changes:**

- Added support for Kindle authentication.
- Refactored authentication to make it simpler to add new providers.
- Added tests to ensure authentication works as expected.

**Environment Variables:**

- `AUTH_PROVIDER`: Use this variable to set the desired authentication provider (`auth0` or `kinde`).
- `AUTH_LOGOUT_URL`: For the Kinde provider, specify the logout URL here.
