### PR TITLE
Add database connection checks before running migrations.

### DIFF
--- a/app/src/Application/Bootloader/AppBootloader.php
+++ b/app/src/Application/Bootloader/AppBootloader.php
@@ -9,8 +9,10 @@ use App\Application\HTTP\Interceptor\JsonResourceInterceptor;
 use App\Application\HTTP\Interceptor\StringToIntParametersInterceptor;
 use App\Application\HTTP\Interceptor\UuidParametersConverterInterceptor;
 use App\Application\Ide\UrlTemplate;
+use App\Interfaces\Console\RegisterModulesCommand;
 use Spiral\Boot\EnvironmentInterface;
 use Spiral\Bootloader\DomainBootloader;
+use Spiral\Console\Bootloader\ConsoleBootloader;
 use Spiral\Core\CoreInterface;
 
 final class AppBootloader extends DomainBootloader
@@ -45,5 +47,14 @@ final class AppBootloader extends DomainBootloader
             UuidParametersConverterInterceptor::class,
             JsonResourceInterceptor::class,
         ];
+    }
+
+    public function init(ConsoleBootloader $console): void
+    {
+        $console->addSequence(
+            name: RegisterModulesCommand::SEQUENCE,
+            sequence: 'database:check-connection',
+            header: 'Check database connection',
+        );
     }
 }

--- a/app/src/Interfaces/Console/CheckDatabaseConnectionCommand.php
+++ b/app/src/Interfaces/Console/CheckDatabaseConnectionCommand.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interfaces\Console;
+
+use Cycle\Database\DatabaseInterface;
+use Spiral\Console\Attribute\AsCommand;
+use Spiral\Console\Command;
+
+#[AsCommand(
+    name: 'database:check-connection',
+    description: 'Check database connection',
+)]
+final class CheckDatabaseConnectionCommand extends Command
+{
+    public function __invoke(DatabaseInterface $db): int
+    {
+        $tries = 0;
+        $multiplier = 1.5;
+
+        do {
+            try {
+                $db->getDriver()->connect();
+                $this->info('Database connection is OK');
+                break;
+            } catch (\Throwable $e) {
+                $tries++;
+                $this->error($e->getMessage());
+                $delay = (int) ($multiplier * $tries);
+                $this->error('Cannot connect to the database. Retrying in ' . $delay . ' second...');
+                \sleep($delay);
+            }
+        } while (true);
+
+        return self::SUCCESS;
+    }
+}


### PR DESCRIPTION
 This should prevent issues where migrations cannot be executed due to race conditions, ensuring the database is initialized before migrations run.