### PR TITLE
New Cleanup Commands for Database and Storage Management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+# ====== Docker ========
+
 build:
 	if [ ! -d "runtime" ]; then \
 		mkdir runtime/configs -p; \
@@ -48,6 +50,27 @@ pull-latest:
 
 build-server:
 	docker compose build buggregator-server --no-cache;
+
+# ====== Database ========
+
+recreate-db:
+	rm -rf .db;
+	mkdir .db;
+	chmod 0777 -R .db;
+	bin/dolt --data-dir=.db sql -q "create database buggregator;";
+
+# ======= Runtime ========
+
+cleanup-attachments:
+	rm -rf runtime/attachments/*;
+
+cleanup-cache:
+	rm -rf runtime/cache;
+
+cleanup-snapshots:
+	rm -rf runtime/snapshots;
+
+cleanup: cleanup-attachments cleanup-cache cleanup-snapshots;
 
 # =========================
 

--- a/app/src/Application/Bootloader/PersistenceBootloader.php
+++ b/app/src/Application/Bootloader/PersistenceBootloader.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Application\Bootloader;
 
+use App\Application\Database\CleanerInterface;
 use App\Application\Persistence\DriverEnum;
+use App\Integration\CycleOrm\DatabaseCleaner;
 use App\Interfaces\Console\RegisterModulesCommand;
 use Spiral\Boot\Bootloader\Bootloader;
 use Spiral\Console\Bootloader\ConsoleBootloader;
@@ -23,6 +25,13 @@ final class PersistenceBootloader extends Bootloader
             CycleBridge\SchemaBootloader::class,
             CycleBridge\CycleOrmBootloader::class,
             CycleBridge\AnnotatedBootloader::class,
+        ];
+    }
+
+    public function defineSingletons(): array
+    {
+        return [
+            CleanerInterface::class => DatabaseCleaner::class,
         ];
     }
 

--- a/app/src/Application/Database/CleanerInterface.php
+++ b/app/src/Application/Database/CleanerInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Database;
+
+interface CleanerInterface
+{
+    public function clean(?string $database = null): \Generator;
+}

--- a/app/src/Integration/CycleOrm/DatabaseCleaner.php
+++ b/app/src/Integration/CycleOrm/DatabaseCleaner.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Integration\CycleOrm;
+
+use App\Application\Database\CleanerInterface;
+use Cycle\Database\DatabaseProviderInterface;
+use Cycle\Migrations\Config\MigrationConfig;
+
+final readonly class DatabaseCleaner implements CleanerInterface
+{
+    public function __construct(
+        private MigrationConfig $config,
+        private DatabaseProviderInterface $provider,
+    ) {}
+
+    public function clean(?string $database = null): \Generator
+    {
+        $db = $this->provider->database($database);
+
+
+        foreach ($db->getTables() as $table) {
+            $this->disableForeignKeyConstraints($database);
+
+            // Skip the table that stores the list of executed migrations
+            if ($table->getName() === $this->config->getTable()) {
+                continue;
+            }
+
+            /**
+             * @psalm-suppress UndefinedInterfaceMethod
+             */
+            $db->getDriver()->getSchemaHandler()->eraseTable($db->table($table->getFullName())->getSchema());
+            yield $table->getName();
+
+            $this->enableForeignKeyConstraints($database);
+        }
+    }
+
+    public function disableForeignKeyConstraints(?string $database = null): void
+    {
+        $db = $this->provider->database($database);
+
+        /**
+         * @psalm-suppress UndefinedInterfaceMethod
+         */
+        $db->getDriver()->getSchemaHandler()->disableForeignKeyConstraints();
+    }
+
+    public function enableForeignKeyConstraints(?string $database = null): void
+    {
+        $db = $this->provider->database($database);
+
+        /**
+         * @psalm-suppress UndefinedInterfaceMethod
+         */
+        $db->getDriver()->getSchemaHandler()->enableForeignKeyConstraints();
+    }
+}

--- a/app/src/Interfaces/Console/CleanupCommand.php
+++ b/app/src/Interfaces/Console/CleanupCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Interfaces\Console;
+
+use App\Application\Database\CleanerInterface;
+use Spiral\Boot\DirectoriesInterface;
+use Spiral\Console\Attribute\AsCommand;
+use Spiral\Console\Command;
+use Spiral\Storage\Config\StorageConfig;
+use Spiral\Storage\StorageInterface;
+
+#[AsCommand(
+    name: 'cleanup',
+    description: 'Clean database and storage data',
+)]
+final class CleanupCommand extends Command
+{
+    public function __invoke(
+        CleanerInterface $cleaner,
+        StorageInterface $storage,
+        DirectoriesInterface $dirs,
+        StorageConfig $config,
+    ): void {
+        $this->info('Cleaning database...');
+
+        foreach ($cleaner->clean() as $table) {
+            $this->writeln(\sprintf('- Table %s cleaned', $table));
+        }
+
+        $this->newLine();
+
+        $this->info('Cleaning storage...');
+        foreach ($config->getAdapters() as $bucket => $adapter) {
+            $adapter->deleteDirectory('*');
+            $this->writeln(\sprintf('- Bucket %s cleaned', $bucket));
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces a new console command for cleaning up databases and storage buckets, as well as enhancements to the Makefile for better local development management.

New Console Command:
To facilitate the cleanup of databases and storage, a new command has been added:

```bash
php app.php cleanup
```

Upon successful execution, the following output confirms the cleanup process:


```bash
Cleaning database...
- Table events cleaned
- Table http_dump_attachments cleaned
- Table projects cleaned
- Table smtp_attachments cleaned
- Table webhook_deliveries cleaned
- Table webhooks cleaned

Cleaning storage...
- Bucket smtp cleaned
- Bucket http_dumps cleaned
```

### Makefile Improvements:

Improves Makefile:
- Adds command to recreate local database (Doltdb)
- Adds commands to cleanup runtime

Several new commands have been added to the Makefile to support various cleanup activities and database management:

#### Cleanup Attachments Storage:
```bash
make cleanup-attachments
```

#### Cleanup Runtime Cache:
```bash
make cleanup-cache
```

#### Cleanup Runtime Snapshots:
```bash
make cleanup-snapshots
```

#### Comprehensive Cleanup (Snapshots, Cache, Attachments):
```bash
make cleanup
```

#### Recreate Doltdb:

> **Warning** All stored data will be deleted

```bash
make recreate-db
```

These additions aim to streamline the maintenance and management of local development environments.
