### PR TITLE
Fixes problem with sending `bool`, `int` and `float` variable types

### DIFF
--- a/app/modules/VarDumper/Application/Dump/MessageParser.php
+++ b/app/modules/VarDumper/Application/Dump/MessageParser.php
@@ -12,10 +12,15 @@ final class MessageParser
 {
     /**
      * @throws \RuntimeException
+     * @throws InvalidPayloadException
      */
     public function parse(string $message): ParsedPayload
     {
-        $payload = @\unserialize(\base64_decode($message), ['allowed_classes' => [Data::class, Stub::class]]);
+        try {
+            $payload = \unserialize(\base64_decode($message), ['allowed_classes' => [Data::class, Stub::class]]);
+        } catch (\Throwable) {
+            $payload = false;
+        }
 
         // Impossible to decode the message, give up.
         if (false === $payload) {

--- a/app/modules/VarDumper/Application/Dump/PrimitiveBody.php
+++ b/app/modules/VarDumper/Application/Dump/PrimitiveBody.php
@@ -8,7 +8,7 @@ final readonly class PrimitiveBody implements BodyInterface
 {
     public function __construct(
         private string $type,
-        private string $value,
+        private mixed $value,
     ) {}
 
     public function getType(): string
@@ -23,11 +23,11 @@ final readonly class PrimitiveBody implements BodyInterface
 
     public function __toString(): string
     {
-        return $this->value;
+        return (string) $this->value;
     }
 
     public function jsonSerialize(): string
     {
-        return $this->__toString();
+        return (string) $this;
     }
 }

--- a/app/modules/VarDumper/Application/Dump/PrimitiveBody.php
+++ b/app/modules/VarDumper/Application/Dump/PrimitiveBody.php
@@ -23,7 +23,11 @@ final readonly class PrimitiveBody implements BodyInterface
 
     public function __toString(): string
     {
-        return (string) $this->value;
+        return match (true) {
+            $this->value === true => '1',
+            $this->value === false => '0',
+            default => (string) $this->value,
+        };
     }
 
     public function jsonSerialize(): string

--- a/app/modules/VarDumper/Interfaces/TCP/Service.php
+++ b/app/modules/VarDumper/Interfaces/TCP/Service.php
@@ -60,7 +60,7 @@ final readonly class Service implements ServiceInterface
 
     private function convertToPrimitive(Data $data): BodyInterface|null
     {
-        if (\in_array($data->getType(), ['string', 'boolean'])) {
+        if (\in_array($data->getType(), ['string', 'boolean', 'integer', 'double'])) {
             return new PrimitiveBody(
                 type: $data->getType(),
                 value: $data->getValue(),

--- a/tests/Feature/Interfaces/TCP/VarDumper/SymfonyV7Test.php
+++ b/tests/Feature/Interfaces/TCP/VarDumper/SymfonyV7Test.php
@@ -7,62 +7,53 @@ namespace Tests\Feature\Interfaces\TCP\VarDumper;
 use App\Application\Broadcasting\Channel\EventsChannel;
 use Modules\VarDumper\Application\Dump\DumpIdGeneratorInterface;
 use Modules\VarDumper\Exception\InvalidPayloadException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\VarDumper\Caster\ReflectionCaster;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Tests\Feature\Interfaces\TCP\TCPTestCase;
 
 final class SymfonyV7Test extends TCPTestCase
 {
-    public function testSendDump(): void
+    public static function variablesDataProvider(): iterable
     {
-        $message = $this->buildPayload(var: 'foo');
-        $this->handleVarDumperRequest($message);
+        yield 'string' => ['foo', 'string', 'foo'];
+        yield 'int' => [1, 'integer', 1];
+        yield 'float' => [1.1, 'double', 1.1];
+        yield 'array' => [['foo' => 'bar'], 'array', <<<'HTML'
+<pre class=sf-dump id=sf-dump-730421088 data-indent-pad="  "><span class=sf-dump-label>Some label</span> <span class=sf-dump-note>array:1</span> [<samp data-depth=1 class=sf-dump-expanded>
+  "<span class=sf-dump-key>foo</span>" => "<span class=sf-dump-str>bar</span>"
+</samp>]
+</pre><script>Sfdump("sf-dump-730421088")</script>
 
-        $this->broadcastig->assertPushed(new EventsChannel(), function (array $data) {
-            $this->assertSame('event.received', $data['event']);
-            $this->assertSame('var-dump', $data['data']['type']);
-
-            $this->assertSame([
-                'type' => 'string',
-                'value' => 'foo',
-                'label' => 'Some label',
-            ], $data['data']['payload']['payload']);
-
-            $this->assertNotEmpty($data['data']['uuid']);
-            $this->assertNotEmpty($data['data']['timestamp']);
-
-            return true;
-        });
-    }
-
-    public function testSendObjectDump(): void
-    {
-        $generator = $this->mockContainer(DumpIdGeneratorInterface::class);
-
-        $generator->shouldReceive('generate')->andReturn('sf-dump-730421088');
-        $object = (object) ['type' => 'string', 'value' => 'foo'];
-        $message = $this->buildPayload($object);
-        $this->handleVarDumperRequest($message);
-        $objectId = \spl_object_id($object);
-
-        $this->broadcastig->assertPushed(new EventsChannel(), function (array $data) use ($objectId) {
-            $this->assertSame('event.received', $data['event']);
-            $this->assertSame('var-dump', $data['data']['type']);
-            $this->assertSame(null, $data['data']['project']);
-
-            $this->assertSame([
-                'type' => 'stdClass',
-                'value' => \sprintf(
-                    <<<HTML
-<pre class=sf-dump id=sf-dump-730421088 data-indent-pad="  "><span class=sf-dump-label>Some label</span> {<a class=sf-dump-ref>#%s</a><samp data-depth=1 class=sf-dump-expanded>
+HTML
+        ];
+        yield 'object' => [(object) ['type' => 'string', 'value' => 'foo'], 'stdClass', <<<HTML
+<pre class=sf-dump id=sf-dump-730421088 data-indent-pad="  "><span class=sf-dump-label>Some label</span> {<a class=sf-dump-ref>#208</a><samp data-depth=1 class=sf-dump-expanded>
   +"<span class=sf-dump-public>type</span>": "<span class=sf-dump-str>string</span>"
   +"<span class=sf-dump-public>value</span>": "<span class=sf-dump-str>foo</span>"
 </samp>}
 </pre><script>Sfdump("sf-dump-730421088")</script>
 
-HTML,
-                    $objectId,
-                ),
+HTML
+        ];
+    }
+
+    #[DataProvider('variablesDataProvider')]
+    public function testSendDump(mixed $value, string $type, mixed $expected): void
+    {
+        $generator = $this->mockContainer(DumpIdGeneratorInterface::class);
+        $generator->shouldReceive('generate')->andReturn('sf-dump-730421088');
+
+        $message = $this->buildPayload(var: $value);
+        $this->handleVarDumperRequest($message);
+
+        $this->broadcastig->assertPushed(new EventsChannel(), function (array $data) use ($value, $type, $expected) {
+            $this->assertSame('event.received', $data['event']);
+            $this->assertSame('var-dump', $data['data']['type']);
+
+            $this->assertSame([
+                'type' => $type,
+                'value' => $expected,
                 'label' => 'Some label',
             ], $data['data']['payload']['payload']);
 

--- a/tests/Feature/Interfaces/TCP/VarDumper/SymfonyV7Test.php
+++ b/tests/Feature/Interfaces/TCP/VarDumper/SymfonyV7Test.php
@@ -17,24 +17,34 @@ final class SymfonyV7Test extends TCPTestCase
     public static function variablesDataProvider(): iterable
     {
         yield 'string' => ['foo', 'string', 'foo'];
-        yield 'int' => [1, 'integer', 1];
-        yield 'float' => [1.1, 'double', 1.1];
-        yield 'array' => [['foo' => 'bar'], 'array', <<<'HTML'
+        yield 'true' => [true, 'boolean', '1'];
+        yield 'false' => [false, 'boolean', '0'];
+        yield 'int' => [1, 'integer', '1'];
+        yield 'float' => [1.1, 'double', '1.1'];
+        yield 'array' => [
+            ['foo' => 'bar'],
+            'array',
+            <<<'HTML'
 <pre class=sf-dump id=sf-dump-730421088 data-indent-pad="  "><span class=sf-dump-label>Some label</span> <span class=sf-dump-note>array:1</span> [<samp data-depth=1 class=sf-dump-expanded>
   "<span class=sf-dump-key>foo</span>" => "<span class=sf-dump-str>bar</span>"
 </samp>]
 </pre><script>Sfdump("sf-dump-730421088")</script>
 
 HTML
+            ,
         ];
-        yield 'object' => [(object) ['type' => 'string', 'value' => 'foo'], 'stdClass', <<<HTML
-<pre class=sf-dump id=sf-dump-730421088 data-indent-pad="  "><span class=sf-dump-label>Some label</span> {<a class=sf-dump-ref>#208</a><samp data-depth=1 class=sf-dump-expanded>
+        yield 'object' => [
+            (object) ['type' => 'string', 'value' => 'foo'],
+            'stdClass',
+            <<<HTML
+<pre class=sf-dump id=sf-dump-730421088 data-indent-pad="  "><span class=sf-dump-label>Some label</span> {<a class=sf-dump-ref>#%s</a><samp data-depth=1 class=sf-dump-expanded>
   +"<span class=sf-dump-public>type</span>": "<span class=sf-dump-str>string</span>"
   +"<span class=sf-dump-public>value</span>": "<span class=sf-dump-str>foo</span>"
 </samp>}
 </pre><script>Sfdump("sf-dump-730421088")</script>
 
 HTML
+            ,
         ];
     }
 
@@ -46,6 +56,10 @@ HTML
 
         $message = $this->buildPayload(var: $value);
         $this->handleVarDumperRequest($message);
+
+        if (\is_object($value)) {
+            $expected = \sprintf($expected, \spl_object_id($value));
+        }
 
         $this->broadcastig->assertPushed(new EventsChannel(), function (array $data) use ($value, $type, $expected) {
             $this->assertSame('event.received', $data['event']);


### PR DESCRIPTION
```
TypeError: Modules\VarDumper\Application\Dump\PrimitiveBody::__construct(): Argument #2 ($value) must be of type string, bool given, called in /app/app/modules/VarDumper/Interfaces/TCP/Service.php on line 64 in /app/app/modules/VarDumper/Application/Dump/PrimitiveBody.php at line 9 [] []
```