### PR TITLE
Adjust the duration for the flamegraph to milliseconds instead of microseconds.

### DIFF
--- a/app/modules/Profiler/Interfaces/Queries/FindFlameChartByUuidHandler.php
+++ b/app/modules/Profiler/Interfaces/Queries/FindFlameChartByUuidHandler.php
@@ -42,7 +42,7 @@ final readonly class FindFlameChartByUuidHandler
             $eventData = [
                 'name' => $edge->getCallee(),
                 'start' => 0,  // Temporarily zero, will adjust based on the parent later
-                'duration' => $duration,
+                'duration' => $duration > 0 ? \round($duration / 1_000, 3) : 0,
                 'type' => 'task',
                 'children' => [],
                 'cost' => [
@@ -72,7 +72,7 @@ final readonly class FindFlameChartByUuidHandler
         return $waterfall;
     }
 
-    private function adjustStartTimes(&$eventList, $startTime): void
+    private function adjustStartTimes(array &$eventList, float|int $startTime): void
     {
         foreach ($eventList as &$event) {
             $event['start'] = $startTime;


### PR DESCRIPTION
Before 🤡
![image](https://github.com/buggregator/server/assets/773481/f6f1dbc3-9ddf-42bb-8e23-1656bdadc5b0)

After 😎
![image](https://github.com/buggregator/server/assets/773481/f01849f0-e437-41a6-8614-b2b8c32f260b)
