### PR TITLE
Add platform detection to get-binaries.sh

### DIFF
--- a/bin/get-binaries.sh
+++ b/bin/get-binaries.sh
@@ -1,13 +1,33 @@
-echo "Download centrifugo"
-wget --timeout=10 https://github.com/centrifugal/centrifugo/releases/download/v4.0.3/centrifugo_4.0.3_linux_amd64.tar.gz
-tar xvfz centrifugo_4.0.3_linux_amd64.tar.gz centrifugo
-rm -rf centrifugo_4.0.3_linux_amd64.tar.gz
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+if ! command -v wget &> /dev/null
+then
+    echo "wget could not be found. Please install wget and try again."
+    exit 1
+fi
+
+if [ "$ARCH" = "x86_64" ]; then
+    ARCH="amd64"
+elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
+    ARCH="arm64"
+else
+    echo "Failed to download binaries unsupported architecture: $ARCH"
+    exit 1
+fi
+
+echo "Detected OS: $OS, Architecture: $ARCH"
+
+echo "Downloading Centrifugo"
+wget --timeout=10 "https://github.com/centrifugal/centrifugo/releases/download/v4.0.3/centrifugo_4.0.3_${OS}_${ARCH}.tar.gz"
+tar xvfz centrifugo_4.0.3_${OS}_${ARCH}.tar.gz centrifugo
+rm -rf centrifugo_4.0.3_${OS}_${ARCH}.tar.gz
 chmod +x centrifugo
 
-echo "Download dolt db"
-wget --timeout=10 https://github.com/dolthub/dolt/releases/download/v1.42.8/dolt-linux-amd64.tar.gz
-tar xvfz dolt-linux-amd64.tar.gz dolt-linux-amd64/bin/dolt
-rm -rf dolt-linux-amd64.tar.gz
-mv dolt-linux-amd64/bin/dolt dolt
-rm -rf dolt-linux-amd64
+echo "Downloading Dolt"
+wget --timeout=10 "https://github.com/dolthub/dolt/releases/download/v1.42.8/dolt-$OS-$ARCH.tar.gz"
+tar xvfz dolt-$OS-$ARCH.tar.gz dolt-$OS-$ARCH/bin/dolt
+rm -rf dolt-$OS-$ARCH.tar.gz
+mv dolt-$OS-$ARCH/bin/dolt dolt
+rm -rf dolt-$OS-$ARCH
 chmod +x dolt


### PR DESCRIPTION
Hey,

I encountered some issues while setting up a local copy during testing for #243.

The get-binaries script downloaded the wrong binaries for my platform. When I tried installing via Homebrew instead, it installed the latest version of Dolt, which led me to run into issue #237.

I believe adding platform detection to the get-binaries script would be beneficial for other developers in the future.