### PR TITLE
Issue/#74 hide unused feature

### DIFF
--- a/app/src/Application/Bootloader/AppBootloader.php
+++ b/app/src/Application/Bootloader/AppBootloader.php
@@ -9,6 +9,7 @@ use Psr\Container\ContainerInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Spiral\Core\InterceptableCore;
 use App\Application\AppVersion;
+use App\Application\Client\Settings;
 use App\Application\HTTP\Interceptor\JsonResourceInterceptor;
 use App\Application\HTTP\Interceptor\StringToIntParametersInterceptor;
 use App\Application\HTTP\Interceptor\UuidParametersConverterInterceptor;
@@ -40,6 +41,18 @@ final class AppBootloader extends DomainBootloader
                 EnvironmentInterface $env,
             ): AppVersion => new AppVersion(
                 version: $env->get('APP_VERSION', 'dev'),
+            ),
+
+            Settings::class => fn(
+                EnvironmentInterface $env,
+            ): AppVersion => new AppVersion(
+                version: $env->get('APP_VERSION', 'dev'),
+            ),
+
+            ClientSettings::class => fn(
+                EnvironmentInterface $env,
+            ): ClientSettings => new ClientSettings(
+                version: $env->get('CLIENT_SUPPORTED_EVENTS', 'http-dump,inspector,monolog,profiler,ray,sentry,smtp,var-dump'),
             ),
         ];
     }

--- a/app/src/Application/Bootloader/AppBootloader.php
+++ b/app/src/Application/Bootloader/AppBootloader.php
@@ -45,14 +45,8 @@ final class AppBootloader extends DomainBootloader
 
             Settings::class => fn(
                 EnvironmentInterface $env,
-            ): AppVersion => new AppVersion(
-                version: $env->get('APP_VERSION', 'dev'),
-            ),
-
-            ClientSettings::class => fn(
-                EnvironmentInterface $env,
-            ): ClientSettings => new ClientSettings(
-                version: $env->get('CLIENT_SUPPORTED_EVENTS', 'http-dump,inspector,monolog,profiler,ray,sentry,smtp,var-dump'),
+            ): Settings => new Settings(
+                supportedEvents: $env->get('CLIENT_SUPPORTED_EVENTS', 'http-dump,inspector,monolog,profiler,ray,sentry,smtp,var-dump'),
             ),
         ];
     }

--- a/app/src/Application/Client/Settings.php
+++ b/app/src/Application/Client/Settings.php
@@ -7,7 +7,7 @@ namespace App\Application\Client;
 use Spiral\Core\Attribute\Singleton;
 
 #[Singleton]
-final readonly class ClientSettings
+final readonly class Settings
 {
     public function __construct(
         public string $supportedEvents,

--- a/app/src/Application/Client/Settings.php
+++ b/app/src/Application/Client/Settings.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Client;
+
+use Spiral\Core\Attribute\Singleton;
+
+#[Singleton]
+final readonly class ClientSettings
+{
+    public function __construct(
+        public string $supportedEvents,
+    ) {}
+}

--- a/app/src/Interfaces/Http/Controller/SettingsAction.php
+++ b/app/src/Interfaces/Http/Controller/SettingsAction.php
@@ -9,6 +9,7 @@ use App\Application\Auth\AuthSettings;
 use App\Application\HTTP\Response\JsonResource;
 use App\Application\HTTP\Response\ResourceInterface;
 use App\Application\Ide\UrlTemplate;
+use App\Application\Client\Settings;
 use Spiral\Boot\EnvironmentInterface;
 use Spiral\Router\Annotation\Route;
 
@@ -20,6 +21,7 @@ final class SettingsAction
         AuthSettings $settings,
         UrlTemplate $ideUrl,
         AppVersion $appVersion,
+        ClientSettings $clientSettings,
     ): ResourceInterface {
         return new JsonResource([
             'auth' => [
@@ -30,6 +32,9 @@ final class SettingsAction
                 'url_template' => $ideUrl->template,
             ],
             'version' => $appVersion->version,
+            'client' => [
+                'events' => $clientSettings->supportedEvents,
+            ]
         ]);
     }
 }

--- a/app/src/Interfaces/Http/Controller/SettingsAction.php
+++ b/app/src/Interfaces/Http/Controller/SettingsAction.php
@@ -23,6 +23,8 @@ final class SettingsAction
         AppVersion $appVersion,
         ClientSettings $clientSettings,
     ): ResourceInterface {
+        $supportedEvents = \explode(',', $clientSettings->supportedEvents);
+
         return new JsonResource([
             'auth' => [
                 'enabled' => $settings->enabled,
@@ -33,7 +35,7 @@ final class SettingsAction
             ],
             'version' => $appVersion->version,
             'client' => [
-                'events' => $clientSettings->supportedEvents,
+                'events' => $supportedEvents,
             ]
         ]);
     }

--- a/app/src/Interfaces/Http/Controller/SettingsAction.php
+++ b/app/src/Interfaces/Http/Controller/SettingsAction.php
@@ -21,9 +21,9 @@ final class SettingsAction
         AuthSettings $settings,
         UrlTemplate $ideUrl,
         AppVersion $appVersion,
-        ClientSettings $clientSettings,
+        Settings $clientSettings,
     ): ResourceInterface {
-        $supportedEvents = \explode(',', $clientSettings->supportedEvents);
+        $supportedEvents = \array_filter(\explode(',', $clientSettings->supportedEvents));
 
         return new JsonResource([
             'auth' => [

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -53,14 +53,16 @@ services:
       AUTH_SCOPES: openid,email,profile
 
       # Client
-      CLIENT_SUPPORTED_EVENTS: ${CLIENT_SUPPORTED_EVENTS}
+      CLIENT_SUPPORTED_EVENTS: http-dump,inspector,monolog,profiler,ray,sentry,smtp,var-dump
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.buggregator-http.entrypoints=web"
       - "traefik.http.routers.buggregator-http.rule=Host(`buggregator.localhost`)"
       - "traefik.http.services.buggregator-http.loadbalancer.server.port=8000"
     volumes:
-      - ./:/app
+      - ./app:/app/app
+      - ./runtime:/app/runtime
+      - ./vendor:/app/vendor
     networks:
       - buggregator-network
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -51,6 +51,9 @@ services:
       AUTH_CLIENT_SECRET: ${AUTH_CLIENT_SECRET}
       AUTH_CALLBACK_URL: http://buggregator.localhost/auth/sso/callback
       AUTH_SCOPES: openid,email,profile
+
+      # Client
+      CLIENT_SUPPORTED_EVENTS: ${CLIENT_SUPPORTED_EVENTS}
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.buggregator-http.entrypoints=web"


### PR DESCRIPTION
Add Env based settings to configure visible event types on the client dashboard.

- [x] - add new env variable to the system
- [x] -  add new data to the /settings API with env data
- [x] - polish docker_compose file to run the Server App on the MacOS 


Front-end issue: https://github.com/buggregator/frontend/issues/74