### PR TITLE
Improve docker image deployment action

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build-release:
+    name: GitHub Container Registry
     if: "!github.event.release.prerelease"
     runs-on: ubuntu-latest
 
@@ -31,7 +32,7 @@ jobs:
         id: docker_meta
         uses: docker/metadata-action@v5
         with:
-          images: butschster/buggregator
+          images: ghcr.io/buggregator/server
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -55,6 +56,7 @@ jobs:
           cache-to: type=gha,mode=max
 
   build-docker-release:
+    name: Docker Hub
     if: "!github.event.release.prerelease"
     runs-on: ubuntu-latest
 
@@ -78,7 +80,7 @@ jobs:
         id: docker_meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/buggregator/server
+          images: butschster/buggregator
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,39 +13,46 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: 'Get Previous tag'
-        id: previoustag
-        uses: "WyriHaximus/github-action-get-previous-tag@v1"
-        with:
-          fallback: v0.1
-
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ secrets.GHCR_LOGIN }}
           password: ${{ secrets.GHCR_PASSWORD }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: docker_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: butschster/buggregator
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: ./
           platforms: linux/amd64,linux/arm64
           file: ./.docker/Dockerfile
           push: true
           build-args: |
-            APP_VERSION=${{ steps.previoustag.outputs.tag }}
+            APP_VERSION=${{ github.ref_name }}
             FRONTEND_IMAGE_TAG=latest
-          tags:
-            ghcr.io/${{ github.repository }}:latest, ghcr.io/${{ github.repository }}:${{ steps.previoustag.outputs.tag }}
+            BRANCH=${{ github.ref_name }}
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   build-docker-release:
     if: "!github.event.release.prerelease"
@@ -54,36 +61,42 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: 'Get Previous tag'
-        id: previoustag
-        uses: "WyriHaximus/github-action-get-previous-tag@v1"
-        with:
-          fallback: v0.1
-
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: docker_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/buggregator/server
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: ./
           platforms: linux/amd64,linux/arm64
           file: ./.docker/Dockerfile
           push: true
-          build-args:
-            APP_VERSION=${{ steps.previoustag.outputs.tag }}
+          build-args: |
+            APP_VERSION=${{ github.ref_name }}
             FRONTEND_IMAGE_TAG=latest
-            BRANCH=${{ steps.previoustag.outputs.tag }}
-          tags:
-            ${{ secrets.DOCKER_HUB_USERNAME }}/buggregator:latest, ${{ secrets.DOCKER_HUB_USERNAME }}/buggregator:${{ steps.previoustag.outputs.tag }}
+            BRANCH=${{ github.ref_name }}
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
I've done a few things here:
 - Remove the need for `WyriHaximus/github-action-get-previous-tag` by replacing it with `${{ github.ref_name }}`.
 - Add names to each job to better identify what they're doing.
 - Update all Docker actions to the latest versions available.
 - Generate Tags and Labels using Docker Metadata action to generate semver style tags for releases.


Fixes #252 