### PR TITLE
Add transaction to the Inspector type whitelist

### DIFF
--- a/app/modules/Inspector/Interfaces/Http/Handler/EventHandler.php
+++ b/app/modules/Inspector/Interfaces/Http/Handler/EventHandler.php
@@ -45,6 +45,7 @@ final readonly class EventHandler implements HandlerInterface
         $type = $data[0]['type'] ?? 'unknown';
 
         $data = match ($type) {
+            'transaction',
             'process',
             'request' => $data,
             default => throw new BadRequestException(


### PR DESCRIPTION
This way we have all types that we KNOW are used by Inspector whitelisted

https://github.com/inspector-apm/inspector-php/blob/56ffba7906d0b125a0e35fceb314890a7983aab0/src/Models/Transaction.php#L27

https://github.com/inspector-apm/inspector-php/blob/56ffba7906d0b125a0e35fceb314890a7983aab0/src/Models/Segment.php#L19

https://github.com/inspector-apm/inspector-php/blob/56ffba7906d0b125a0e35fceb314890a7983aab0/src/Models/Transaction.php#L39