### PR TITLE
Increased max depth in json_encode for FlameChart

### DIFF
--- a/app/modules/Profiler/Interfaces/Queries/FindFlameChartByUuidHandler.php
+++ b/app/modules/Profiler/Interfaces/Queries/FindFlameChartByUuidHandler.php
@@ -67,7 +67,7 @@ final readonly class FindFlameChartByUuidHandler
         }
 
         $this->adjustStartTimes($waterfall, 0);
-        $this->bucket->write($file, \json_encode($waterfall));
+        $this->bucket->write($file, \json_encode($waterfall, 0, 5000));
 
         return $waterfall;
     }


### PR DESCRIPTION
Magento's architecture can lead to a significant call stack depth, exceeding 512 child elements.

As a result, the **FlameChart** tab in the profiler show empty page and backend returns a "Maximum stack depth exceeded" error when executing `json_encode`.

This pull request increases the allowed depth in `json_encode` to resolve this issue.