### PR TITLE
SMTP: Use decoded Subject header instead of raw value

### DIFF
--- a/app/modules/Smtp/Interfaces/Jobs/EmailHandler.php
+++ b/app/modules/Smtp/Interfaces/Jobs/EmailHandler.php
@@ -37,7 +37,7 @@ final class EmailHandler extends JobHandler
             sender: $data['envelope']['from'],
             recipients: $data['envelope']['to'],
             ccs: $data['envelope']['ccs'],
-            subject: $data['message']['subject'],
+            subject: $message->getHeaderValue('subject', $data['message']['subject']),
             htmlBody: (string) $message->getHtmlContent(),
             textBody: (string) $message->getTextContent(),
             replyTo: $data['envelope']['replyTo'],


### PR DESCRIPTION
Currently Subject mail header is shown as raw value (which may be MIME-encoded):

<img width="904" height="138" alt="image" src="https://github.com/user-attachments/assets/2fe29b5b-3f88-4067-bb86-babc4a7f8833" />

