### PR TITLE
Sentry: Fix `Invalid type: session` errors

### DIFF
--- a/app/modules/Sentry/Application/DTO/Type.php
+++ b/app/modules/Sentry/Application/DTO/Type.php
@@ -8,6 +8,7 @@ enum Type
 {
     case Event;
     case Transaction;
+    case Session;
     case ReplyEvent;
     case ReplayRecording;
     case Span;

--- a/app/modules/Sentry/Application/DTO/TypeChunk.php
+++ b/app/modules/Sentry/Application/DTO/TypeChunk.php
@@ -12,6 +12,7 @@ final readonly class TypeChunk extends JsonChunk
             'event' => Type::Event,
             'span' => Type::Span,
             'transaction' => Type::Transaction,
+            'session' => Type::Session,
             'replay_event' => Type::ReplyEvent,
             'replay_recording' => Type::ReplayRecording,
             default => throw new \InvalidArgumentException('Invalid type: ' . $this->data['type']),


### PR DESCRIPTION
Looks like `session` events are considered valid, though currently not supported:

https://github.com/buggregator/server/blob/dd838babdde89382c9902c39089e5ea6b05eaa3e/app/modules/Sentry/Interfaces/Http/Handler/EventHandler.php#L78-L87

https://github.com/buggregator/server/blob/dd838babdde89382c9902c39089e5ea6b05eaa3e/app/modules/Sentry/Interfaces/Http/Handler/JsEventHandler.php#L51-L58

So adding another `match` branch to `TypeChunk::type` should be enough for now.

Fixes #289
