### PR TITLE
Fix duplicate OpenAPI Attachment schemas

### DIFF
--- a/app/modules/HttpDumps/Interfaces/Http/Resources/AttachmentResource.php
+++ b/app/modules/HttpDumps/Interfaces/Http/Resources/AttachmentResource.php
@@ -13,7 +13,7 @@ use OpenApi\Attributes as OA;
  * @property-read Attachment $data
  */
 #[OA\Schema(
-    schema: 'Attachment',
+    schema: 'HttpDumpAttachment',
     properties: [
         new OA\Property(property: 'uuid', type: 'string', format: 'uuid'),
         new OA\Property(property: 'name', type: 'string'),

--- a/app/modules/Smtp/Interfaces/Http/Resources/AttachmentResource.php
+++ b/app/modules/Smtp/Interfaces/Http/Resources/AttachmentResource.php
@@ -13,7 +13,7 @@ use OpenApi\Attributes as OA;
  * @property-read Attachment $data
  */
 #[OA\Schema(
-    schema: 'Attachment',
+    schema: 'SmtpAttachment',
     properties: [
         new OA\Property(property: 'uuid', type: 'string', format: 'uuid'),
         new OA\Property(property: 'name', type: 'string'),


### PR DESCRIPTION
### What was fixed
- Removed duplicate `Attachment` OpenAPI schema definitions

### Why
- Duplicate schemas cause OpenAPI generation errors
- This fix makes API docs generation deterministic