### PR TITLE
feature: Add events pagination

### DIFF
--- a/app/modules/Events/Domain/EventRepositoryInterface.php
+++ b/app/modules/Events/Domain/EventRepositoryInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Modules\Events\Domain;
 
+use Cycle\ORM\Select;
 use Cycle\ORM\RepositoryInterface;
 
 /**
@@ -14,7 +15,11 @@ interface EventRepositoryInterface extends RepositoryInterface
 {
     public function findAll(array $scope = [], array $orderBy = [], int $limit = 30, int $offset = 0): iterable;
 
+    public function select(): Select;
+
     public function countAll(array $scope = []): int;
+
+    public function countByType(array $scope = []): array;
 
     public function store(Event $event): bool;
 

--- a/app/modules/Events/Integration/CycleOrm/EventRepository.php
+++ b/app/modules/Events/Integration/CycleOrm/EventRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Modules\Events\Integration\CycleOrm;
 
 use Cycle\Database\DatabaseInterface;
+use Cycle\Database\Injection\Fragment;
 use Cycle\ORM\EntityManagerInterface;
 use Cycle\ORM\Select;
 use Cycle\ORM\Select\Repository;
@@ -59,6 +60,20 @@ final class EventRepository extends Repository implements EventRepositoryInterfa
         return $this->select()
             ->where($this->buildScope($scope))
             ->count();
+    }
+
+    public function countByType(array $scope = []): array
+    {
+        return $this->db
+            ->select()
+            ->from(Event::TABLE_NAME)
+            ->columns([
+                Event::TYPE,
+                new Fragment('COUNT(*) AS cnt'),
+            ])
+            ->where($this->buildScope($scope))
+            ->groupBy(Event::TYPE)
+            ->fetchAll();
     }
 
     public function findAll(array $scope = [], array $orderBy = [], int $limit = 30, int $offset = 0): iterable

--- a/app/modules/Events/Interfaces/Http/Controllers/PreviewListAction.php
+++ b/app/modules/Events/Interfaces/Http/Controllers/PreviewListAction.php
@@ -4,19 +4,21 @@ declare(strict_types=1);
 
 namespace Modules\Events\Interfaces\Http\Controllers;
 
-use App\Application\Commands\FindEvents;
+use App\Application\Commands\FindEventsCursor;
 use App\Application\Event\EventTypeMapperInterface;
 use App\Application\HTTP\Response\ErrorResource;
 use Modules\Events\Interfaces\Http\Request\EventsRequest;
-use Modules\Events\Interfaces\Http\Resources\EventPreviewCollection;
+use Modules\Events\Interfaces\Http\Resources\EventPreviewCursorCollection;
 use Modules\Events\Interfaces\Http\Resources\EventPreviewResource;
+use Modules\Events\Interfaces\Queries\EventsCursorResult;
 use Spiral\Cqrs\QueryBusInterface;
 use Spiral\Router\Annotation\Route;
 use OpenApi\Attributes as OA;
+use Spiral\Http\Request\InputManager;
 
 #[OA\Get(
     path: '/api/events/preview',
-    description: 'Retrieve all events preview',
+    description: 'Retrieve event previews with cursor pagination. Uses a composite cursor (timestamp + uuid) ordered by timestamp DESC, uuid DESC. Use meta.next_cursor as the cursor parameter to fetch the next page; meta.has_more indicates more data.',
     tags: ['Events'],
     parameters: [
         new OA\QueryParameter(
@@ -27,7 +29,19 @@ use OpenApi\Attributes as OA;
         ),
         new OA\QueryParameter(
             name: 'project',
-            description: 'Filter by event type',
+            description: 'Filter by event project',
+            required: false,
+            schema: new OA\Schema(type: 'string'),
+        ),
+        new OA\QueryParameter(
+            name: 'limit',
+            description: 'Page size (default 100, max 100)',
+            required: false,
+            schema: new OA\Schema(type: 'integer', maximum: 100, minimum: 1),
+        ),
+        new OA\QueryParameter(
+            name: 'cursor',
+            description: 'Opaque composite cursor (timestamp + uuid) from meta.next_cursor of the previous response',
             required: false,
             schema: new OA\Schema(type: 'string'),
         ),
@@ -47,7 +61,12 @@ use OpenApi\Attributes as OA;
                     ),
                     new OA\Property(
                         property: 'meta',
-                        ref: '#/components/schemas/ResponseMeta',
+                        properties: [
+                            new OA\Property(property: 'grid', type: 'array', items: new OA\Items()),
+                            new OA\Property(property: 'limit', type: 'integer'),
+                            new OA\Property(property: 'has_more', type: 'boolean'),
+                            new OA\Property(property: 'next_cursor', type: 'string', nullable: true),
+                        ],
                         type: 'object',
                     ),
                 ],
@@ -67,14 +86,29 @@ final readonly class PreviewListAction
     #[Route(route: 'events/preview', name: 'events.preview.list', methods: 'GET', group: 'api')]
     public function __invoke(
         EventsRequest $request,
+        InputManager $input,
         QueryBusInterface $bus,
         EventTypeMapperInterface $mapper,
-    ): EventPreviewCollection {
-        return new EventPreviewCollection(
-            $bus->ask(
-                new FindEvents(type: $request->type, project: $request->project),
+    ): EventPreviewCursorCollection {
+        $limit = $input->query->get('limit');
+        $cursor = $input->query->get('cursor');
+
+        /** @var EventsCursorResult $result */
+        $result = $bus->ask(
+            new FindEventsCursor(
+                type: $request->type,
+                project: $request->project,
+                limit: $limit,
+                cursor: $cursor,
             ),
+        );
+
+        return new EventPreviewCursorCollection(
+            $result->items,
             $mapper,
+            $result->limit,
+            $result->hasMore,
+            $result->nextCursor,
         );
     }
 }

--- a/app/modules/Events/Interfaces/Http/Controllers/TypeCountsAction.php
+++ b/app/modules/Events/Interfaces/Http/Controllers/TypeCountsAction.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Events\Interfaces\Http\Controllers;
+
+use App\Application\Commands\CountEventsByType;
+use App\Application\HTTP\Response\ErrorResource;
+use Modules\Events\Interfaces\Http\Request\EventsRequest;
+use Modules\Events\Interfaces\Http\Resources\EventTypeCountCollection;
+use Modules\Events\Interfaces\Http\Resources\EventTypeCountResource;
+use OpenApi\Attributes as OA;
+use Spiral\Cqrs\QueryBusInterface;
+use Spiral\Router\Annotation\Route;
+
+#[OA\Get(
+    path: '/api/events/type-counts',
+    description: 'Retrieve event counts grouped by type',
+    tags: ['Events'],
+    parameters: [
+        new OA\QueryParameter(
+            name: 'type',
+            description: 'Filter by event type',
+            required: false,
+            schema: new OA\Schema(type: 'string'),
+        ),
+        new OA\QueryParameter(
+            name: 'project',
+            description: 'Filter by event project',
+            required: false,
+            schema: new OA\Schema(type: 'string'),
+        ),
+    ],
+    responses: [
+        new OA\Response(
+            response: 200,
+            description: 'Success',
+            content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(
+                        property: 'data',
+                        type: 'array',
+                        items: new OA\Items(
+                            ref: EventTypeCountResource::class,
+                        ),
+                    ),
+                    new OA\Property(
+                        property: 'meta',
+                        ref: '#/components/schemas/ResponseMeta',
+                        type: 'object',
+                    ),
+                ],
+            ),
+        ),
+        new OA\Response(
+            response: 404,
+            description: 'Not found',
+            content: new OA\JsonContent(
+                ref: ErrorResource::class,
+            ),
+        ),
+    ],
+)]
+final readonly class TypeCountsAction
+{
+    #[Route(route: 'events/type-counts', name: 'events.type-counts', methods: 'GET', group: 'api')]
+    public function __invoke(
+        EventsRequest $request,
+        QueryBusInterface $bus,
+    ): EventTypeCountCollection {
+        return new EventTypeCountCollection(
+            $bus->ask(
+                new CountEventsByType(type: $request->type, project: $request->project),
+            ),
+        );
+    }
+}

--- a/app/modules/Events/Interfaces/Http/Pagination/EventsCursor.php
+++ b/app/modules/Events/Interfaces/Http/Pagination/EventsCursor.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Events\Interfaces\Http\Pagination;
+
+use Modules\Events\Domain\Event;
+use Ramsey\Uuid\Uuid;
+use Spiral\Filters\Exception\ValidationException;
+
+final readonly class EventsCursor
+{
+    public function __construct(
+        private string $timestamp,
+        private string $uuid,
+    ) {}
+
+    public static function fromEvent(Event $event): self
+    {
+        return new self(
+            (string) $event->getTimestamp(),
+            (string) $event->getUuid(),
+        );
+    }
+
+    public static function fromOpaque(string $cursor): self
+    {
+        $decoded = self::decode($cursor);
+        $payload = \json_decode($decoded, true);
+
+        if (!\is_array($payload)) {
+            throw self::invalid('Invalid cursor payload.');
+        }
+
+        $timestamp = $payload['ts'] ?? null;
+        $uuid = $payload['uuid'] ?? null;
+
+        if (!\is_string($timestamp) || !self::isValidTimestamp($timestamp)) {
+            throw self::invalid('Invalid cursor timestamp.');
+        }
+
+        if (!\is_string($uuid) || !Uuid::isValid($uuid)) {
+            throw self::invalid('Invalid cursor UUID.');
+        }
+
+        return new self($timestamp, $uuid);
+    }
+
+    public function toOpaque(): string
+    {
+        $payload = \json_encode(
+            [
+                'ts' => $this->timestamp,
+                'uuid' => $this->uuid,
+            ],
+            \JSON_UNESCAPED_SLASHES,
+        );
+
+        if ($payload === false) {
+            throw self::invalid('Unable to encode cursor.');
+        }
+
+        return self::encode($payload);
+    }
+
+    public function getTimestamp(): string
+    {
+        return $this->timestamp;
+    }
+
+    public function getUuid(): string
+    {
+        return $this->uuid;
+    }
+
+    private static function encode(string $value): string
+    {
+        return \rtrim(\strtr(\base64_encode($value), '+/', '-_'), '=');
+    }
+
+    private static function decode(string $value): string
+    {
+        $decoded = \base64_decode(self::padBase64Url($value), true);
+        if ($decoded === false) {
+            throw self::invalid('Invalid cursor encoding.');
+        }
+
+        return $decoded;
+    }
+
+    private static function padBase64Url(string $value): string
+    {
+        $value = \strtr($value, '-_', '+/');
+        $padding = \strlen($value) % 4;
+
+        return $padding === 0 ? $value : $value . \str_repeat('=', 4 - $padding);
+    }
+
+    private static function isValidTimestamp(string $value): bool
+    {
+        return (bool) \preg_match('/^\d+(?:\.\d+)?$/', $value);
+    }
+
+    private static function invalid(string $message): ValidationException
+    {
+        return new ValidationException([
+            'cursor' => [$message],
+        ], 'Invalid cursor.');
+    }
+}

--- a/app/modules/Events/Interfaces/Http/Resources/EventCursorCollection.php
+++ b/app/modules/Events/Interfaces/Http/Resources/EventCursorCollection.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Events\Interfaces\Http\Resources;
+
+use App\Application\HTTP\Response\ResourceCollection;
+
+final class EventCursorCollection extends ResourceCollection
+{
+    public function __construct(
+        iterable $data,
+        private readonly int $limit,
+        private readonly bool $hasMore,
+        private readonly ?string $nextCursor,
+    ) {
+        parent::__construct(
+            $data,
+            EventResource::class,
+        );
+    }
+
+    protected function wrapData(array $data, array $meta = []): array
+    {
+        $meta = [
+            'limit' => $this->limit,
+            'has_more' => $this->hasMore,
+            'next_cursor' => $this->nextCursor,
+        ];
+
+        return parent::wrapData($data, $meta);
+    }
+}

--- a/app/modules/Events/Interfaces/Http/Resources/EventPreviewCursorCollection.php
+++ b/app/modules/Events/Interfaces/Http/Resources/EventPreviewCursorCollection.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Events\Interfaces\Http\Resources;
+
+use App\Application\Event\EventTypeMapperInterface;
+use App\Application\HTTP\Response\ResourceCollection;
+use Modules\Events\Domain\Event;
+
+final class EventPreviewCursorCollection extends ResourceCollection
+{
+    public function __construct(
+        iterable $data,
+        EventTypeMapperInterface $mapper,
+        private readonly int $limit,
+        private readonly bool $hasMore,
+        private readonly ?string $nextCursor,
+    ) {
+        parent::__construct(
+            $data,
+            static fn(Event $event) => new EventPreviewResource($event, $mapper),
+        );
+    }
+
+    protected function wrapData(array $data, array $meta = []): array
+    {
+        $meta = [
+            'limit' => $this->limit,
+            'has_more' => $this->hasMore,
+            'next_cursor' => $this->nextCursor,
+        ];
+
+        return parent::wrapData($data, $meta);
+    }
+}

--- a/app/modules/Events/Interfaces/Http/Resources/EventTypeCountCollection.php
+++ b/app/modules/Events/Interfaces/Http/Resources/EventTypeCountCollection.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Events\Interfaces\Http\Resources;
+
+use App\Application\HTTP\Response\ResourceCollection;
+
+final class EventTypeCountCollection extends ResourceCollection
+{
+    public function __construct(
+        iterable $data,
+    ) {
+        parent::__construct(
+            $data,
+            EventTypeCountResource::class,
+        );
+    }
+}

--- a/app/modules/Events/Interfaces/Http/Resources/EventTypeCountResource.php
+++ b/app/modules/Events/Interfaces/Http/Resources/EventTypeCountResource.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Events\Interfaces\Http\Resources;
+
+use App\Application\HTTP\Response\JsonResource;
+use OpenApi\Attributes as OA;
+
+/**
+ * @property-read array{type: string, cnt: int|string} $data
+ */
+#[OA\Schema(
+    schema: 'EventTypeCount',
+    properties: [
+        new OA\Property(property: 'type', type: 'string'),
+        new OA\Property(property: 'count', type: 'integer'),
+    ],
+)]
+final class EventTypeCountResource extends JsonResource
+{
+    protected function mapData(): array|\JsonSerializable
+    {
+        return [
+            'type' => $this->data['type'],
+            'count' => (int) $this->data['cnt'],
+        ];
+    }
+}

--- a/app/modules/Events/Interfaces/Queries/CountEventsByTypeHandler.php
+++ b/app/modules/Events/Interfaces/Queries/CountEventsByTypeHandler.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Events\Interfaces\Queries;
+
+use App\Application\Commands\CountEventsByType;
+use Modules\Events\Domain\EventRepositoryInterface;
+use Spiral\Cqrs\Attribute\QueryHandler;
+use Spiral\Cqrs\QueryBusInterface;
+
+final class CountEventsByTypeHandler extends EventsHandler
+{
+    public function __construct(
+        private readonly EventRepositoryInterface $events,
+        QueryBusInterface $bus,
+    ) {
+        parent::__construct($bus);
+    }
+
+    #[QueryHandler]
+    public function __invoke(CountEventsByType $query): array
+    {
+        return $this->events->countByType($this->getScopeFromFindEvents($query));
+    }
+}

--- a/app/modules/Events/Interfaces/Queries/EventsCursorResult.php
+++ b/app/modules/Events/Interfaces/Queries/EventsCursorResult.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Events\Interfaces\Queries;
+
+final readonly class EventsCursorResult
+{
+    /**
+     * @param array $items
+     */
+    public function __construct(
+        public array $items,
+        public int $limit,
+        public bool $hasMore,
+        public ?string $nextCursor,
+    ) {}
+}

--- a/app/modules/Events/Interfaces/Queries/FindEventsCursorHandler.php
+++ b/app/modules/Events/Interfaces/Queries/FindEventsCursorHandler.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Events\Interfaces\Queries;
+
+use App\Application\Commands\FindEventsCursor;
+use Cycle\Database\DatabaseInterface;
+use Cycle\Database\Driver\MySQL\MySQLDriver;
+use Cycle\Database\Driver\Postgres\PostgresDriver;
+use Cycle\Database\Driver\SQLite\SQLiteDriver;
+use Cycle\Database\Driver\SQLServer\SQLServerDriver;
+use Cycle\Database\Injection\Fragment;
+use Cycle\ORM\Select;
+use Modules\Events\Domain\Event;
+use Modules\Events\Domain\EventRepositoryInterface;
+use Modules\Events\Interfaces\Http\Pagination\EventsCursor;
+use Spiral\Cqrs\Attribute\QueryHandler;
+use Spiral\Cqrs\QueryBusInterface;
+use Spiral\Filters\Exception\ValidationException;
+use Psr\Log\LoggerInterface;
+
+final class FindEventsCursorHandler extends EventsHandler
+{
+    private const DEFAULT_LIMIT = 100;
+    private const MAX_LIMIT = 100;
+
+    public function __construct(
+        private readonly EventRepositoryInterface $events,
+        private LoggerInterface $logger,
+        private readonly DatabaseInterface $db,
+        QueryBusInterface $bus,
+    ) {
+        parent::__construct($bus);
+    }
+
+    #[QueryHandler]
+    public function __invoke(FindEventsCursor $query): EventsCursorResult
+    {
+        $limit = $this->resolveLimit($query->limit);
+        $cursor = $this->resolveCursor($query->cursor);
+
+        $source = $this->events->select();
+        $scope = $this->getScopeFromFindEvents($query);
+        if ($scope !== []) {
+            $source = $this->applyScope($source, $scope);
+        }
+
+        if ($cursor !== null) {
+            $source = $this->applyCursor($source, $cursor);
+        }
+
+        $items = $this->applyOrder($source)
+            ->limit($limit + 1)
+            ->fetchAll();
+
+        $hasMore = \count($items) > $limit;
+        if ($hasMore) {
+            \array_pop($items);
+        }
+
+        $nextCursor = null;
+        if ($hasMore && $items !== []) {
+            $last = $items[\array_key_last($items)];
+            if ($last instanceof Event) {
+                $nextCursor = EventsCursor::fromEvent($last)->toOpaque();
+            }
+        }
+
+        return new EventsCursorResult(
+            $items,
+            $limit,
+            $hasMore,
+            $nextCursor,
+        );
+    }
+
+    private function applyScope(Select $select, array $scope): Select
+    {
+        $normalized = [];
+
+        foreach ($scope as $key => $value) {
+            $normalized[$key] = \is_array($value) ? ['in' => $value] : $value;
+        }
+
+        return $select->where($normalized);
+    }
+
+    private function applyCursor(Select $select, EventsCursor $cursor): Select
+    {
+        $timestampExpression = $this->timestampExpression();
+
+        return $select->where(
+            static function ($query) use ($cursor, $timestampExpression): void {
+                $query
+                    ->where(new Fragment($timestampExpression), '<', $cursor->getTimestamp())
+                    ->orWhere(
+                        static function ($query) use ($cursor, $timestampExpression): void {
+                            $query
+                                ->where(new Fragment($timestampExpression), '=', $cursor->getTimestamp())
+                                ->andWhere(Event::UUID, '<', $cursor->getUuid());
+                        },
+                    );
+            },
+        );
+    }
+
+    private function applyOrder(Select $select): Select
+    {
+        $select = $select->orderBy(new Fragment($this->timestampExpression()), 'DESC');
+
+        return $select->orderBy(Event::UUID, 'DESC');
+    }
+
+    private function timestampExpression(): string
+    {
+        $driver = $this->db->getDriver();
+        $table = $driver->identifier(Event::ROLE);
+        $column = $driver->identifier(Event::TIMESTAMP);
+        $expression = "{$table}.{$column}";
+
+        return match (true) {
+            $driver instanceof MySQLDriver, $driver instanceof SQLServerDriver =>
+                sprintf('CAST(%s AS DECIMAL(20,6))', $expression),
+
+            $driver instanceof SQLiteDriver =>
+                sprintf('CAST(%s AS REAL)', $expression),
+
+            $driver instanceof PostgresDriver =>
+                sprintf('CAST(%s AS numeric)', $expression),
+
+            default =>
+                throw new \RuntimeException('Unsupported DB driver'),
+        };
+    }
+
+    private function resolveLimit(mixed $value): int
+    {
+        if ($value === null || $value === '') {
+            return self::DEFAULT_LIMIT;
+        }
+
+        if (!\is_numeric($value)) {
+            throw $this->invalidLimit();
+        }
+
+        $limit = (int) $value;
+        if ($limit < 1) {
+            throw $this->invalidLimit();
+        }
+
+        return \min($limit, self::MAX_LIMIT);
+    }
+
+    private function resolveCursor(mixed $value): ?EventsCursor
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (!\is_string($value)) {
+            throw $this->invalidCursor();
+        }
+
+        return EventsCursor::fromOpaque($value);
+    }
+
+    private function invalidLimit(): ValidationException
+    {
+        return new ValidationException([
+            'limit' => ['Limit must be a positive integer.'],
+        ], 'Invalid pagination limit.');
+    }
+
+    private function invalidCursor(): ValidationException
+    {
+        return new ValidationException([
+            'cursor' => ['Cursor must be a string.'],
+        ], 'Invalid cursor.');
+    }
+}

--- a/app/src/Application/Commands/CountEventsByType.php
+++ b/app/src/Application/Commands/CountEventsByType.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Commands;
+
+final class CountEventsByType extends AskEvents {}

--- a/app/src/Application/Commands/FindEventsCursor.php
+++ b/app/src/Application/Commands/FindEventsCursor.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Commands;
+
+use Spiral\Cqrs\QueryInterface;
+
+/**
+ * @implements QueryInterface<mixed>
+ */
+final class FindEventsCursor extends AskEvents implements QueryInterface
+{
+    public function __construct(
+        ?string $type = null,
+        ?string $project = null,
+        public readonly mixed $limit = null,
+        public readonly mixed $cursor = null,
+    ) {
+        parent::__construct($type, $project);
+    }
+}

--- a/app/src/Application/HTTP/Response/ResourceCollection.php
+++ b/app/src/Application/HTTP/Response/ResourceCollection.php
@@ -64,7 +64,7 @@ class ResourceCollection implements ResourceInterface
         return $this->writeJson($response, $this);
     }
 
-    protected function wrapData(array $data): array
+    protected function wrapData(array $data, array $meta = []): array
     {
         $grid = [];
 
@@ -77,6 +77,7 @@ class ResourceCollection implements ResourceInterface
         return [
             'data' => $data,
             'meta' => [
+                ...$meta,
                 'grid' => $grid,
             ],
         ];

--- a/tests/App/Http/HttpFaker.php
+++ b/tests/App/Http/HttpFaker.php
@@ -113,6 +113,87 @@ final class HttpFaker
         );
     }
 
+    public function typeCounts(?string $type = null, ?string $project = null): ResponseAssertions
+    {
+        $args = [];
+        if ($type) {
+            $args['type'] = $type;
+        }
+
+        if ($project) {
+            $args['project'] = $project;
+        }
+
+        return $this->makeResponse(
+            $this->http->get(
+                uri: '/api/events/type-counts',
+                query: $args,
+            ),
+        );
+    }
+
+    public function listEvents(
+        ?string $type = null,
+        ?string $project = null,
+        ?int $limit = null,
+        ?string $cursor = null,
+    ): ResponseAssertions {
+        $args = [];
+        if ($type) {
+            $args['type'] = $type;
+        }
+
+        if ($project) {
+            $args['project'] = $project;
+        }
+
+        if ($limit !== null) {
+            $args['limit'] = $limit;
+        }
+
+        if ($cursor !== null) {
+            $args['cursor'] = $cursor;
+        }
+
+        return $this->makeResponse(
+            $this->http->get(
+                uri: '/api/events',
+                query: $args,
+            ),
+        );
+    }
+
+    public function previewEvents(
+        ?string $type = null,
+        ?string $project = null,
+        ?int $limit = null,
+        ?string $cursor = null,
+    ): ResponseAssertions {
+        $args = [];
+        if ($type) {
+            $args['type'] = $type;
+        }
+
+        if ($project) {
+            $args['project'] = $project;
+        }
+
+        if ($limit !== null) {
+            $args['limit'] = $limit;
+        }
+
+        if ($cursor !== null) {
+            $args['cursor'] = $cursor;
+        }
+
+        return $this->makeResponse(
+            $this->http->get(
+                uri: '/api/events/preview',
+                query: $args,
+            ),
+        );
+    }
+
     public function __call(string $name, array $arguments): ResponseAssertions|self
     {
         if (!method_exists($this->http, $name)) {

--- a/tests/App/Http/ResponseAssertions.php
+++ b/tests/App/Http/ResponseAssertions.php
@@ -118,6 +118,13 @@ final readonly class ResponseAssertions
         return $this;
     }
 
+    public function json(): array
+    {
+        $data = \json_decode((string) $this->response, true);
+
+        return \is_array($data) ? $data : [];
+    }
+
     public function assertJsonResponseContains(array $data): self
     {
         $needle = \json_encode($data);

--- a/tests/Feature/Interfaces/Http/Events/ListActionTest.php
+++ b/tests/Feature/Interfaces/Http/Events/ListActionTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Interfaces\Http\Events;
+
+use Database\Factory\EventFactory;
+use Modules\Events\Domain\Event;
+use Modules\Events\Domain\EventRepositoryInterface;
+use Modules\Events\Domain\ValueObject\Timestamp;
+use Modules\Projects\Domain\ValueObject\Key;
+use Tests\Feature\Interfaces\Http\ControllerTestCase;
+
+final class ListActionTest extends ControllerTestCase
+{
+    public function testCursorPagination(): void
+    {
+        $event1 = $this->createEventWithTimestamp('100');
+        $event2 = $this->createEventWithTimestamp('200');
+        $event3 = $this->createEventWithTimestamp('300');
+
+        $response = $this->http
+            ->listEvents(limit: 2)
+            ->assertOk();
+
+        $data = $response->json();
+
+        $this->assertCount(2, $data['data']);
+        $this->assertSame(2, $data['meta']['limit']);
+        $this->assertTrue($data['meta']['has_more']);
+        $this->assertNotEmpty($data['meta']['next_cursor']);
+
+        $this->assertSame((string) $event3->getUuid(), $data['data'][0]['uuid']);
+        $this->assertSame((string) $event2->getUuid(), $data['data'][1]['uuid']);
+
+        $nextResponse = $this->http
+            ->listEvents(limit: 2, cursor: $data['meta']['next_cursor'])
+            ->assertOk();
+
+        $nextData = $nextResponse->json();
+
+        $this->assertCount(1, $nextData['data']);
+        $this->assertSame(2, $nextData['meta']['limit']);
+        $this->assertFalse($nextData['meta']['has_more']);
+        $this->assertNull($nextData['meta']['next_cursor']);
+        $this->assertSame((string) $event1->getUuid(), $nextData['data'][0]['uuid']);
+    }
+
+    public function testInvalidLimit(): void
+    {
+        $response = $this->http
+            ->listEvents(limit: 0)
+            ->assertUnprocessable()
+            ->assertJsonResponseContains([
+                'message' => 'The given data was invalid.',
+                'code' => 422,
+                'context' => 'Invalid pagination limit.',
+            ]);
+
+        $data = $response->json();
+
+        $this->assertSame(['Limit must be a positive integer.'], $data['errors']['limit']);
+    }
+
+    private function createEventWithTimestamp(string $timestamp): Event
+    {
+        $event = EventFactory::new([
+            'type' => 'foo',
+            'project' => Key::create('default'),
+            'timestamp' => Timestamp::typecast($timestamp),
+        ])->makeOne();
+
+        $this->get(EventRepositoryInterface::class)->store($event);
+
+        return $event;
+    }
+}

--- a/tests/Feature/Interfaces/Http/Events/PreviewListActionTest.php
+++ b/tests/Feature/Interfaces/Http/Events/PreviewListActionTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Interfaces\Http\Events;
+
+use Database\Factory\EventFactory;
+use Modules\Events\Domain\Event;
+use Modules\Events\Domain\EventRepositoryInterface;
+use Modules\Events\Domain\ValueObject\Timestamp;
+use Modules\Projects\Domain\ValueObject\Key;
+use Tests\Feature\Interfaces\Http\ControllerTestCase;
+
+final class PreviewListActionTest extends ControllerTestCase
+{
+    public function testCursorPagination(): void
+    {
+        $event1 = $this->createEventWithTimestamp('100');
+        $event2 = $this->createEventWithTimestamp('200');
+        $event3 = $this->createEventWithTimestamp('300');
+
+        $response = $this->http
+            ->previewEvents(limit: 2)
+            ->assertOk();
+
+        $data = $response->json();
+
+        $this->assertCount(2, $data['data']);
+        $this->assertSame(2, $data['meta']['limit']);
+        $this->assertTrue($data['meta']['has_more']);
+        $this->assertNotEmpty($data['meta']['next_cursor']);
+
+        $this->assertSame((string) $event3->getUuid(), $data['data'][0]['uuid']);
+        $this->assertSame((string) $event2->getUuid(), $data['data'][1]['uuid']);
+
+        $nextResponse = $this->http
+            ->previewEvents(limit: 2, cursor: $data['meta']['next_cursor'])
+            ->assertOk();
+
+        $nextData = $nextResponse->json();
+
+        $this->assertCount(1, $nextData['data']);
+        $this->assertSame(2, $nextData['meta']['limit']);
+        $this->assertFalse($nextData['meta']['has_more']);
+        $this->assertNull($nextData['meta']['next_cursor']);
+        $this->assertSame((string) $event1->getUuid(), $nextData['data'][0]['uuid']);
+    }
+
+    public function testInvalidCursor(): void
+    {
+        $response = $this->http
+            ->previewEvents(cursor: 'invalid!!')
+            ->assertUnprocessable()
+            ->assertJsonResponseContains([
+                'message' => 'The given data was invalid.',
+                'code' => 422,
+                'context' => 'Invalid cursor.',
+            ]);
+
+        $data = $response->json();
+
+        $this->assertSame(['Invalid cursor encoding.'], $data['errors']['cursor']);
+    }
+
+    private function createEventWithTimestamp(string $timestamp): Event
+    {
+        $event = EventFactory::new([
+            'type' => 'foo',
+            'project' => Key::create('default'),
+            'timestamp' => Timestamp::typecast($timestamp),
+        ])->makeOne();
+
+        $this->get(EventRepositoryInterface::class)->store($event);
+
+        return $event;
+    }
+}

--- a/tests/Feature/Interfaces/Http/Events/TypeCountsActionTest.php
+++ b/tests/Feature/Interfaces/Http/Events/TypeCountsActionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Interfaces\Http\Events;
+
+use Modules\Events\Interfaces\Http\Resources\EventTypeCountResource;
+use Tests\Feature\Interfaces\Http\ControllerTestCase;
+
+final class TypeCountsActionTest extends ControllerTestCase
+{
+    public function testTypeCountsByProject(): void
+    {
+        $this->createEvent(type: 'foo', project: 'alpha');
+        $this->createEvent(type: 'foo', project: 'alpha');
+        $this->createEvent(type: 'bar', project: 'alpha');
+        $this->createEvent(type: 'baz', project: 'beta');
+
+        $this->http
+            ->typeCounts(project: 'alpha')
+            ->assertOk()
+            ->assertCollectionContainResources([
+                new EventTypeCountResource(['type' => 'foo', 'cnt' => 2]),
+                new EventTypeCountResource(['type' => 'bar', 'cnt' => 1]),
+            ])
+            ->assertCollectionMissingResources([
+                new EventTypeCountResource(['type' => 'baz', 'cnt' => 1]),
+            ]);
+    }
+
+    public function testTypeCountsByProjectAndType(): void
+    {
+        $this->createEvent(type: 'foo', project: 'alpha');
+        $this->createEvent(type: 'foo', project: 'alpha');
+        $this->createEvent(type: 'bar', project: 'alpha');
+
+        $this->http
+            ->typeCounts(type: 'foo', project: 'alpha')
+            ->assertOk()
+            ->assertCollectionContainResources([
+                new EventTypeCountResource(['type' => 'foo', 'cnt' => 2]),
+            ])
+            ->assertCollectionMissingResources([
+                new EventTypeCountResource(['type' => 'bar', 'cnt' => 1]),
+            ]);
+    }
+}


### PR DESCRIPTION
### Summary

This PR adds **cursor-based pagination** for events, designed for a dynamic event stream where new events may continuously appear.

The API is intended for practical frontend usage with infinite scrolling and avoids issues typical for offset-based pagination (duplicates, gaps, unstable ordering).

---

### Pagination approach

Instead of offsets, the API uses a **composite cursor** based on the last item of the previous page.

Each page response returns:

```json
{
  "limit": 25,
  "has_more": true,
  "next_cursor": "base64(...)"
}
```

The `next_cursor` encodes a `(timestamp, uuid)` pair.  
On the next request, the server returns events **strictly after** this pair, ordered by:

```
(timestamp, uuid)
```

This guarantees stable ordering and deterministic pagination, even when timestamps are equal.

The cursor is transferred as Base64 for simplicity and to prevent client-side modification.

---

### Server-side changes

- Extended `/api/events` and `/api/events/preview` with cursor-based pagination  
  (backward compatibility preserved)
- Added `/api/events/type-counts` endpoint to return the current number of events per type
- Implemented ordering by `timestamp`; since the column is stored as string, casting is used:
  ```sql
  CAST(timestamp AS DECIMAL(20,6))
  ```
- Added API documentation and tests for new and updated endpoints
- Removed the previous hard limit of 100 events — events can now be loaded dynamically

---

### Result

The server now provides a stable and scalable pagination mechanism suitable for infinite scrolling and large, continuously growing event streams.
