### PR TITLE
Fix GitHub token leak in Docker image builds

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -2,7 +2,6 @@ ARG ROAD_RUNNER_IMAGE=2024.2.1
 ARG CENTRIFUGO_IMAGE=v4
 ARG DOLT_IMAGE=1.42.8
 ARG FRONTEND_IMAGE_TAG=latest
-ARG GH_TOKEN
 
 # Build centrifugo binary
 FROM centrifugo/centrifugo:$CENTRIFUGO_IMAGE as centrifugo
@@ -16,7 +15,6 @@ FROM golang:1.25-alpine as rr
 
 ARG APP_VERSION="2025.1.1"
 ARG VELOX_CONFIG="velox.toml"
-ARG GH_TOKEN
 
 # copy required files from builder image
 COPY --from=velox /usr/bin/vx /usr/bin/vx
@@ -24,13 +22,15 @@ COPY ${VELOX_CONFIG} .
 
 # we don't need CGO
 ENV CGO_ENABLED=0
-ENV RT_TOKEN=${GH_TOKEN}
 ARG CACHE_BUST=1
 
 RUN echo $CACHE_BUST
 
-# RUN build
-RUN vx build -c velox.toml -o /usr/bin/
+# Build RoadRunner with velox. The GitHub token is mounted as a secret
+# and never stored in image layers.
+RUN --mount=type=secret,id=gh_token \
+    RT_TOKEN=$(cat /run/secrets/gh_token) \
+    vx build -c velox.toml -o /usr/bin/
 
 # Build JS files
 FROM ghcr.io/buggregator/frontend:$FRONTEND_IMAGE_TAG as frontend

--- a/.github/workflows/docker-dev-image.yml
+++ b/.github/workflows/docker-dev-image.yml
@@ -45,7 +45,8 @@ jobs:
             APP_VERSION=${{ steps.previoustag.outputs.tag }}
             FRONTEND_IMAGE_TAG=latest
             BRANCH=${{ steps.previoustag.outputs.tag }}
-            GH_TOKEN=${{ secrets.GHCR_PASSWORD }}
             VELOX_CONFIG=./.docker/velox.toml
+          secrets: |
+            gh_token=${{ secrets.GHCR_PASSWORD }}
           tags:
             ghcr.io/${{ github.repository }}:dev, ghcr.io/${{ github.repository }}:${{ steps.previoustag.outputs.tag }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -99,8 +99,9 @@ jobs:
             APP_VERSION=${{ github.ref_name }}
             FRONTEND_IMAGE_TAG=${{ secrets.FRONTEND_IMAGE_TAG }}
             BRANCH=${{ github.ref_name }}
-            GH_TOKEN=${{ secrets.GHCR_PASSWORD }}
             VELOX_CONFIG=./.docker/velox.toml
+          secrets: |
+            gh_token=${{ secrets.GHCR_PASSWORD }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
           cache-from: type=gha

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,8 +28,10 @@ services:
     build:
       dockerfile: Dockerfile
       context: .docker
+      secrets:
+        - gh_token
       args:
-        GH_TOKEN: "${GH_TOKEN}"
+        VELOX_CONFIG: velox.toml
     environment:
 #      RR_LOG_LEVEL: debug
       #      RR_LOG_TCP_LEVEL: debug
@@ -118,6 +120,10 @@ services:
       - buggregator-pgsql
     networks:
       - buggregator-network
+
+secrets:
+  gh_token:
+    environment: "GH_TOKEN"
 
 networks:
   buggregator-network:


### PR DESCRIPTION
## Summary

- **Security fix**: `GH_TOKEN` was passed as `--build-arg` and stored via `ENV` in image layers, making it visible through `docker history`/`docker inspect` to anyone pulling the published image
- Switch to **BuildKit secrets** (`RUN --mount=type=secret`): the token is mounted in memory only during the `RUN` command and never persisted in any image layer
- Update both GitHub Actions workflows (`docker-image.yml`, `docker-dev-image.yml`) to pass token via `secrets:` instead of `build-args:`
- Update `docker-compose.yaml` to use `secrets` definition sourced from `GH_TOKEN` environment variable

## Test plan

- [ ] Verify Docker image builds successfully in CI with the new secret mount
- [ ] Run `docker history` on the built image and confirm no token is visible
- [ ] Verify local `GH_TOKEN=... docker compose build` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)