### PR TITLE
Add searchable_text support and upsert optimization

### DIFF
--- a/app/modules/Events/Application/Broadcasting/EventWasReceivedMapper.php
+++ b/app/modules/Events/Application/Broadcasting/EventWasReceivedMapper.php
@@ -33,6 +33,10 @@ final readonly class EventWasReceivedMapper implements EventMapperInterface
                     payload: $event->event->getPayload(),
                 ),
                 'timestamp' => $event->event->getTimestamp(),
+                'searchable_text' => $this->eventTypeMapper->toSearchableText(
+                    type: $event->event->getType(),
+                    payload: $event->event->getPayload(),
+                ),
             ],
         );
     }

--- a/app/modules/Events/Application/EventsBootloader.php
+++ b/app/modules/Events/Application/EventsBootloader.php
@@ -7,7 +7,6 @@ namespace Modules\Events\Application;
 use App\Application\Broadcasting\EventMapperRegistryInterface;
 use App\Application\Persistence\DriverEnum;
 use Cycle\Database\DatabaseInterface;
-use Cycle\ORM\EntityManagerInterface;
 use Cycle\ORM\ORMInterface;
 use Cycle\ORM\Select;
 use Modules\Events\Application\Broadcasting\EventsWasClearMapper;
@@ -38,10 +37,8 @@ final class EventsBootloader extends Bootloader
             },
             EventRepository::class => static fn(
                 ORMInterface $orm,
-                EntityManagerInterface $manager,
                 DatabaseInterface $db,
             ): EventRepository => new EventRepository(
-                em: $manager,
                 db: $db,
                 select: new Select($orm, Event::class),
             ),

--- a/app/modules/Events/Integration/CycleOrm/EventRepository.php
+++ b/app/modules/Events/Integration/CycleOrm/EventRepository.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Modules\Events\Integration\CycleOrm;
 
 use Cycle\Database\DatabaseInterface;
-use Cycle\ORM\EntityManagerInterface;
 use Cycle\ORM\Select;
 use Cycle\ORM\Select\Repository;
 use Modules\Events\Domain\Event;
@@ -18,7 +17,6 @@ use Modules\Events\Domain\EventRepositoryInterface;
 final class EventRepository extends Repository implements EventRepositoryInterface
 {
     public function __construct(
-        private readonly EntityManagerInterface $em,
         private readonly DatabaseInterface $db,
         Select $select,
     ) {
@@ -27,14 +25,22 @@ final class EventRepository extends Repository implements EventRepositoryInterfa
 
     public function store(Event $event): bool
     {
-        if (($found = $this->findByPK($event->getUuid())) !== null) {
-            $found->setPayload($event->getPayload());
-            $this->em->persist($found);
-        } else {
-            $this->em->persist($event);
-        }
+        $payload = (string) $event->getPayload();
 
-        $this->em->run();
+        try {
+            $this->db->insert(Event::TABLE_NAME)->values([
+                Event::UUID => (string) $event->getUuid(),
+                Event::TYPE => $event->getType(),
+                Event::PAYLOAD => $payload,
+                Event::TIMESTAMP => (string) $event->getTimestamp(),
+                Event::PROJECT => $event->getProject() !== null ? (string) $event->getProject() : null,
+            ])->run();
+        } catch (\Throwable) {
+            $this->db->update(Event::TABLE_NAME)
+                ->where(Event::UUID, (string) $event->getUuid())
+                ->values([Event::PAYLOAD => $payload])
+                ->run();
+        }
 
         return true;
     }

--- a/app/modules/Events/Interfaces/Http/Resources/EventPreviewResource.php
+++ b/app/modules/Events/Interfaces/Http/Resources/EventPreviewResource.php
@@ -20,6 +20,7 @@ use OpenApi\Attributes as OA;
         new OA\Property(property: 'type', type: 'string'),
         new OA\Property(property: 'payload', description: 'Event payload based on type', type: 'object'),
         new OA\Property(property: 'timestamp', type: 'float', example: 1630540800.12312),
+        new OA\Property(property: 'searchable_text', description: 'Concatenated searchable content', type: 'string'),
     ],
 )]
 final class EventPreviewResource extends JsonResource
@@ -42,6 +43,10 @@ final class EventPreviewResource extends JsonResource
                 payload: $this->data->getPayload(),
             ) ?? $this->data->getPayload(),
             'timestamp' => $this->data->getTimestamp(),
+            'searchable_text' => $this->mapper?->toSearchableText(
+                type: $this->data->getType(),
+                payload: $this->data->getPayload(),
+            ) ?? '',
         ];
     }
 }

--- a/app/modules/HttpDumps/Application/HttpDumpsBootloader.php
+++ b/app/modules/HttpDumps/Application/HttpDumpsBootloader.php
@@ -9,12 +9,14 @@ use Cycle\ORM\EntityManagerInterface;
 use Cycle\ORM\ORMInterface;
 use Cycle\ORM\Select;
 use Modules\HttpDumps\EventHandler;
+use Modules\HttpDumps\Application\Mapper\EventTypeMapper;
 use Modules\HttpDumps\Application\Storage\AttachmentStorage;
 use Modules\HttpDumps\Domain\AttachmentFactoryInterface;
 use Modules\HttpDumps\Domain\AttachmentRepositoryInterface;
 use Modules\HttpDumps\Domain\AttachmentStorageInterface;
 use Modules\HttpDumps\Domain\Attachment;
 use Modules\HttpDumps\Integration\CycleOrm\AttachmentRepository;
+use App\Application\Event\EventTypeRegistryInterface;
 use Psr\Container\ContainerInterface;
 use Spiral\Boot\Bootloader\Bootloader;
 use Spiral\Core\FactoryInterface;
@@ -57,5 +59,10 @@ final class HttpDumpsBootloader extends Bootloader
                 default => throw new \Exception('Unsupported database driver'),
             },
         ];
+    }
+
+    public function boot(EventTypeRegistryInterface $registry): void
+    {
+        $registry->register('http-dump', new EventTypeMapper());
     }
 }

--- a/app/modules/HttpDumps/Application/Mapper/EventTypeMapper.php
+++ b/app/modules/HttpDumps/Application/Mapper/EventTypeMapper.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\HttpDumps\Application\Mapper;
+
+use App\Application\Event\EventTypeMapperInterface;
+
+final readonly class EventTypeMapper implements EventTypeMapperInterface
+{
+    public function toPreview(string $type, array|\JsonSerializable $payload): array|\JsonSerializable
+    {
+        return $payload;
+    }
+
+    public function toSearchableText(string $type, array|\JsonSerializable $payload): string
+    {
+        $data = $payload instanceof \JsonSerializable ? $payload->jsonSerialize() : $payload;
+
+        return \implode(' ', \array_filter([
+            $data['host'] ?? null,
+            $data['request']['method'] ?? null,
+            $data['request']['uri'] ?? null,
+        ]));
+    }
+}

--- a/app/modules/Inspector/Application/Mapper/EventTypeMapper.php
+++ b/app/modules/Inspector/Application/Mapper/EventTypeMapper.php
@@ -25,4 +25,24 @@ final readonly class EventTypeMapper implements EventTypeMapperInterface
             $transaction,
         ];
     }
+
+    public function toSearchableText(string $type, array|\JsonSerializable $payload): string
+    {
+        $data = $payload instanceof \JsonSerializable ? $payload->jsonSerialize() : $payload;
+
+        $parts = [];
+
+        foreach ($data as $block) {
+            if (!is_array($block)) {
+                continue;
+            }
+            foreach (['model', 'name', 'type', 'host'] as $key) {
+                if (isset($block[$key]) && \is_string($block[$key])) {
+                    $parts[] = $block[$key];
+                }
+            }
+        }
+
+        return \implode(' ', $parts);
+    }
 }

--- a/app/modules/Monolog/Application/Mapper/EventTypeMapper.php
+++ b/app/modules/Monolog/Application/Mapper/EventTypeMapper.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Monolog\Application\Mapper;
+
+use App\Application\Event\EventTypeMapperInterface;
+
+final readonly class EventTypeMapper implements EventTypeMapperInterface
+{
+    public function toPreview(string $type, array|\JsonSerializable $payload): array|\JsonSerializable
+    {
+        return $payload;
+    }
+
+    public function toSearchableText(string $type, array|\JsonSerializable $payload): string
+    {
+        $data = $payload instanceof \JsonSerializable ? $payload->jsonSerialize() : $payload;
+
+        return \implode(' ', \array_filter([
+            $data['message'] ?? null,
+            $data['channel'] ?? null,
+            $data['level_name'] ?? null,
+        ]));
+    }
+}

--- a/app/modules/Monolog/Application/MonologEventBootloader.php
+++ b/app/modules/Monolog/Application/MonologEventBootloader.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Monolog\Application;
+
+use Modules\Monolog\Application\Mapper\EventTypeMapper;
+use App\Application\Event\EventTypeRegistryInterface;
+use Spiral\Boot\Bootloader\Bootloader;
+
+final class MonologEventBootloader extends Bootloader
+{
+    public function boot(EventTypeRegistryInterface $registry): void
+    {
+        $registry->register('monolog', new EventTypeMapper());
+    }
+}

--- a/app/modules/Profiler/Application/Mapper/EventTypeMapper.php
+++ b/app/modules/Profiler/Application/Mapper/EventTypeMapper.php
@@ -20,4 +20,20 @@ final readonly class EventTypeMapper implements EventTypeMapperInterface
             'date' => $data['date'],
         ];
     }
+
+    public function toSearchableText(string $type, array|\JsonSerializable $payload): string
+    {
+        $data = $payload instanceof \JsonSerializable ? $payload->jsonSerialize() : $payload;
+
+        $parts = \array_filter([
+            $data['app_name'] ?? null,
+            $data['hostname'] ?? null,
+        ]);
+
+        foreach (($data['tags'] ?? []) as $key => $value) {
+            $parts[] = \is_string($key) ? "{$key}:{$value}" : $value;
+        }
+
+        return \implode(' ', $parts);
+    }
 }

--- a/app/modules/Sentry/Application/Mapper/EventTypeMapper.php
+++ b/app/modules/Sentry/Application/Mapper/EventTypeMapper.php
@@ -30,6 +30,30 @@ final readonly class EventTypeMapper implements EventTypeMapperInterface
         ];
     }
 
+    public function toSearchableText(string $type, array|\JsonSerializable $payload): string
+    {
+        $data = $payload instanceof \JsonSerializable ? $payload->jsonSerialize() : $payload;
+
+        $parts = \array_filter([
+            $data['message'] ?? null,
+            $data['level'] ?? null,
+            $data['environment'] ?? null,
+            $data['server_name'] ?? null,
+            $data['platform'] ?? null,
+        ]);
+
+        foreach (($data['exception']['values'] ?? []) as $e) {
+            if (isset($e['type'])) {
+                $parts[] = $e['type'];
+            }
+            if (isset($e['value'])) {
+                $parts[] = $e['value'];
+            }
+        }
+
+        return \implode(' ', $parts);
+    }
+
     public function limitExceptionFramesNumber(array|null $exception, int $max = 3): array|null
     {
         if ($exception === null) {

--- a/app/modules/Smtp/Application/Mapper/EventTypeMapper.php
+++ b/app/modules/Smtp/Application/Mapper/EventTypeMapper.php
@@ -18,4 +18,23 @@ final readonly class EventTypeMapper implements EventTypeMapperInterface
             'to' => $data['to'],
         ];
     }
+
+    public function toSearchableText(string $type, array|\JsonSerializable $payload): string
+    {
+        $data = $payload instanceof \JsonSerializable ? $payload->jsonSerialize() : $payload;
+
+        $parts = \array_filter([
+            $data['subject'] ?? null,
+        ]);
+
+        foreach (($data['from'] ?? []) as $address) {
+            $parts[] = \is_array($address) ? ($address['email'] ?? $address['address'] ?? '') : (string) $address;
+        }
+
+        foreach (($data['to'] ?? []) as $address) {
+            $parts[] = \is_array($address) ? ($address['email'] ?? $address['address'] ?? '') : (string) $address;
+        }
+
+        return \implode(' ', $parts);
+    }
 }

--- a/app/src/Application/Event/EventTypeMapper.php
+++ b/app/src/Application/Event/EventTypeMapper.php
@@ -21,6 +21,15 @@ final class EventTypeMapper implements EventTypeMapperInterface, EventTypeRegist
         return $this->mappers[$type]->toPreview($type, $payload);
     }
 
+    public function toSearchableText(string $type, array|\JsonSerializable $payload): string
+    {
+        if (!isset($this->mappers[$type])) {
+            return '';
+        }
+
+        return $this->mappers[$type]->toSearchableText($type, $payload);
+    }
+
     public function register(string $type, EventTypeMapperInterface $mapper): void
     {
         if (isset($this->mappers[$type])) {

--- a/app/src/Application/Event/EventTypeMapperInterface.php
+++ b/app/src/Application/Event/EventTypeMapperInterface.php
@@ -7,4 +7,6 @@ namespace App\Application\Event;
 interface EventTypeMapperInterface
 {
     public function toPreview(string $type, array|\JsonSerializable $payload): array|\JsonSerializable;
+
+    public function toSearchableText(string $type, array|\JsonSerializable $payload): string;
 }

--- a/app/src/Application/Kernel.php
+++ b/app/src/Application/Kernel.php
@@ -21,6 +21,7 @@ use Modules\Profiler\Application\ProfilerBootloader;
 use Modules\Projects\Application\ProjectBootloader;
 use Modules\Ray\Application\RayBootloader;
 use Modules\HttpDumps\Application\HttpDumpsBootloader;
+use Modules\Monolog\Application\MonologEventBootloader;
 use Modules\Sentry\Application\SentryBootloader;
 use Modules\Smtp\Application\SmtpBootloader;
 use Modules\VarDumper\Application\VarDumperBootloader;
@@ -99,6 +100,7 @@ class Kernel extends \Spiral\Framework\Kernel
             VarDumperBootloader::class,
             RayBootloader::class,
             HttpDumpsBootloader::class,
+            MonologEventBootloader::class,
             ProfilerBootloader::class,
             PersistenceBootloader::class,
             WebhooksBootloader::class,

--- a/tests/Unit/Modules/Events/Domain/CacheEventRepositoryTest.php
+++ b/tests/Unit/Modules/Events/Domain/CacheEventRepositoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Modules\Events\Domain;
 
+use App\Application\Domain\ValueObjects\Json;
 use Modules\Events\Domain\EventRepositoryInterface;
 use Tests\DatabaseTestCase;
 
@@ -25,6 +26,52 @@ final class CacheEventRepositoryTest extends DatabaseTestCase
         $this->createEvent();
 
         $this->assertCount(1, \iterator_to_array($this->repository->findAll()));
+    }
+
+    public function testUpsertNewEvent(): void
+    {
+        $event = $this->createEvent(type: 'sentry');
+
+        $this->assertCount(1, \iterator_to_array($this->repository->findAll()));
+
+        $found = $this->repository->findByPK($event->getUuid());
+        $this->assertNotNull($found);
+        $this->assertSame('sentry', $found->getType());
+    }
+
+    public function testUpsertExistingEventUpdatesPayload(): void
+    {
+        $event = $this->createEvent(type: 'sentry');
+
+        $this->assertCount(1, \iterator_to_array($this->repository->findAll()));
+
+        $newPayload = new Json(['updated' => true, 'message' => 'changed']);
+        $event->setPayload($newPayload);
+        $this->repository->store($event);
+
+        $this->assertCount(1, \iterator_to_array($this->repository->findAll()));
+
+        $this->cleanIdentityMap();
+        $found = $this->repository->findByPK($event->getUuid());
+        $this->assertNotNull($found);
+        $this->assertSame(['updated' => true, 'message' => 'changed'], $found->getPayload()->jsonSerialize());
+    }
+
+    public function testUpsertDoesNotDuplicateOnSameUuid(): void
+    {
+        $event = $this->createEvent(type: 'monolog');
+
+        $event->setPayload(new Json(['attempt' => 2]));
+        $this->repository->store($event);
+
+        $event->setPayload(new Json(['attempt' => 3]));
+        $this->repository->store($event);
+
+        $this->assertCount(1, \iterator_to_array($this->repository->findAll()));
+
+        $this->cleanIdentityMap();
+        $found = $this->repository->findByPK($event->getUuid());
+        $this->assertSame(['attempt' => 3], $found->getPayload()->jsonSerialize());
     }
 
     public function testDeleteByType(): void


### PR DESCRIPTION
## Summary
- Add `toSearchableText()` to `EventTypeMapperInterface` and implement in Sentry, Profiler, Inspector, Smtp mappers
- Create new `EventTypeMapper` for Monolog and HttpDumps modules with `toSearchableText()` and pass-through `toPreview()`
- Add `searchable_text` field to `EventPreviewResource` (HTTP) and `EventWasReceivedMapper` (WebSocket broadcast)
- Replace ORM-based SELECT+persist with raw INSERT/UPDATE upsert in `EventRepository::store()`
- Add upsert tests for `EventRepository`

## Test plan
- [x] Unit tests pass (78/78)
- [x] Feature tests pass (pre-existing VarDumper line-ending failures only)
- [x] Verify `searchable_text` appears in preview API response
- [x] Verify `searchable_text` included in WS broadcast

🤖 Generated with [Claude Code](https://claude.com/claude-code)