### PR TITLE
Add searchable text, profiler insights, pinned events & auto-projects

### DIFF
--- a/app/database/Migrations/20260327.000000_0_0_default_change_events_add_is_pinned.php
+++ b/app/database/Migrations/20260327.000000_0_0_default_change_events_add_is_pinned.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Migrations;
+
+use Cycle\Migrations\Migration;
+
+class OrmDefaultAddIsPinnedToEvents extends Migration
+{
+    protected const DATABASE = 'default';
+
+    public function up(): void
+    {
+        $this->table('events')
+            ->addColumn('is_pinned', 'boolean', ['nullable' => false, 'defaultValue' => false])
+            ->update();
+    }
+
+    public function down(): void
+    {
+        $this->table('events')
+            ->dropColumn('is_pinned')
+            ->update();
+    }
+}

--- a/app/modules/Events/Application/Broadcasting/EventWasReceivedMapper.php
+++ b/app/modules/Events/Application/Broadcasting/EventWasReceivedMapper.php
@@ -37,6 +37,7 @@ final readonly class EventWasReceivedMapper implements EventMapperInterface
                     type: $event->event->getType(),
                     payload: $event->event->getPayload(),
                 ),
+                'is_pinned' => $event->event->isPinned(),
             ],
         );
     }

--- a/app/modules/Events/Domain/Event.php
+++ b/app/modules/Events/Domain/Event.php
@@ -29,6 +29,7 @@ class Event
     public const PAYLOAD = 'payload';
     public const TIMESTAMP = 'timestamp';
     public const PROJECT = 'project';
+    public const IS_PINNED = 'is_pinned';
 
     /**  @internal */
     public function __construct(
@@ -42,6 +43,8 @@ class Event
         private Timestamp $timestamp,
         #[Column(type: 'string', name: self::PROJECT, nullable: true, typecast: Key::class)]
         private ?Key $project = null,
+        #[Column(type: 'boolean', name: self::IS_PINNED, default: false)]
+        private bool $isPinned = false,
     ) {}
 
     public function getUuid(): Uuid
@@ -72,5 +75,20 @@ class Event
     public function getProject(): ?Key
     {
         return $this->project;
+    }
+
+    public function isPinned(): bool
+    {
+        return $this->isPinned;
+    }
+
+    public function pin(): void
+    {
+        $this->isPinned = true;
+    }
+
+    public function unpin(): void
+    {
+        $this->isPinned = false;
     }
 }

--- a/app/modules/Events/Domain/EventRepositoryInterface.php
+++ b/app/modules/Events/Domain/EventRepositoryInterface.php
@@ -21,4 +21,8 @@ interface EventRepositoryInterface extends RepositoryInterface
     public function deleteAll(array $scope = []): void;
 
     public function deleteByPK(string $uuid): bool;
+
+    public function pin(string $uuid): bool;
+
+    public function unpin(string $uuid): bool;
 }

--- a/app/modules/Events/Integration/CycleOrm/EventRepository.php
+++ b/app/modules/Events/Integration/CycleOrm/EventRepository.php
@@ -34,6 +34,7 @@ final class EventRepository extends Repository implements EventRepositoryInterfa
                 Event::PAYLOAD => $payload,
                 Event::TIMESTAMP => (string) $event->getTimestamp(),
                 Event::PROJECT => $event->getProject() !== null ? (string) $event->getProject() : null,
+                Event::IS_PINNED => $event->isPinned(),
             ])->run();
         } catch (\Throwable) {
             $this->db->update(Event::TABLE_NAME)
@@ -47,16 +48,35 @@ final class EventRepository extends Repository implements EventRepositoryInterfa
 
     public function deleteAll(array $scope = []): void
     {
-        $this->db
+        $query = $this->db
             ->delete(Event::TABLE_NAME)
-            ->where($this->buildScope($scope))
-            ->run();
+            ->where($this->buildScope($scope));
+
+        $query->where(Event::IS_PINNED, false);
+        $query->run();
     }
 
     public function deleteByPK(string $uuid): bool
     {
         return $this->db->delete(Event::TABLE_NAME)
                 ->where(Event::UUID, $uuid)
+                ->where(Event::IS_PINNED, false)
+                ->run() > 0;
+    }
+
+    public function pin(string $uuid): bool
+    {
+        return $this->db->update(Event::TABLE_NAME)
+                ->where(Event::UUID, $uuid)
+                ->values([Event::IS_PINNED => true])
+                ->run() > 0;
+    }
+
+    public function unpin(string $uuid): bool
+    {
+        return $this->db->update(Event::TABLE_NAME)
+                ->where(Event::UUID, $uuid)
+                ->values([Event::IS_PINNED => false])
                 ->run() > 0;
     }
 

--- a/app/modules/Events/Interfaces/Commands/StoreEventHandler.php
+++ b/app/modules/Events/Interfaces/Commands/StoreEventHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Modules\Events\Interfaces\Commands;
 
+use App\Application\Commands\CreateProject;
 use App\Application\Commands\FindProjectByKey;
 use App\Application\Commands\HandleReceivedEvent;
 use App\Application\Domain\ValueObjects\Json;
@@ -24,16 +25,26 @@ final readonly class StoreEventHandler
         private EventDispatcherInterface $dispatcher,
         private EventRepositoryInterface $events,
         private QueryBusInterface $queryBus,
+        private \Spiral\Cqrs\CommandBusInterface $commandBus,
         private EventMetrics $metrics,
     ) {}
 
     #[CommandHandler]
     public function handle(HandleReceivedEvent $command): void
     {
-        $project = null;
-        // If the project is not null, we will find the project by key
-        if ($command->project !== null) {
-            $project = $this->queryBus->ask(new FindProjectByKey($command->project));
+        $projectKey = $command->project ?? Project::DEFAULT_KEY;
+
+        $project = $this->queryBus->ask(new FindProjectByKey($projectKey));
+
+        if ($project === null) {
+            try {
+                $project = $this->commandBus->dispatch(
+                    new CreateProject(key: $projectKey, name: $projectKey),
+                );
+            } catch (\Throwable) {
+                // Race condition: project was created between check and create
+                $project = $this->queryBus->ask(new FindProjectByKey($projectKey));
+            }
         }
 
         $this->events->store(
@@ -42,7 +53,6 @@ final readonly class StoreEventHandler
                 type: $command->type,
                 payload: new Json($command->payload),
                 timestamp: Timestamp::create(),
-                // todo: use better option for default project
                 project: $project?->getKey() ?? Key::create(Project::DEFAULT_KEY),
             ),
         );

--- a/app/modules/Events/Interfaces/Http/Controllers/PinEventAction.php
+++ b/app/modules/Events/Interfaces/Http/Controllers/PinEventAction.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Events\Interfaces\Http\Controllers;
+
+use App\Application\Domain\ValueObjects\Uuid;
+use Modules\Events\Domain\EventRepositoryInterface;
+use Spiral\Http\Exception\ClientException\NotFoundException;
+use Spiral\Router\Annotation\Route;
+
+final readonly class PinEventAction
+{
+    #[Route(route: 'event/<uuid>/pin', name: 'event.pin', methods: ['POST'], group: 'api')]
+    public function pin(
+        EventRepositoryInterface $events,
+        Uuid $uuid,
+    ): array {
+        if (!$events->pin((string) $uuid)) {
+            throw new NotFoundException('Event not found');
+        }
+
+        return ['status' => 'pinned'];
+    }
+
+    #[Route(route: 'event/<uuid>/pin', name: 'event.unpin', methods: ['DELETE'], group: 'api')]
+    public function unpin(
+        EventRepositoryInterface $events,
+        Uuid $uuid,
+    ): array {
+        if (!$events->unpin((string) $uuid)) {
+            throw new NotFoundException('Event not found');
+        }
+
+        return ['status' => 'unpinned'];
+    }
+}

--- a/app/modules/Events/Interfaces/Http/Resources/EventPreviewResource.php
+++ b/app/modules/Events/Interfaces/Http/Resources/EventPreviewResource.php
@@ -47,6 +47,7 @@ final class EventPreviewResource extends JsonResource
                 type: $this->data->getType(),
                 payload: $this->data->getPayload(),
             ) ?? '',
+            'is_pinned' => $this->data->isPinned(),
         ];
     }
 }

--- a/app/modules/Profiler/Application/Query/CompareProfiles.php
+++ b/app/modules/Profiler/Application/Query/CompareProfiles.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Profiler\Application\Query;
+
+use App\Application\Domain\ValueObjects\Uuid;
+use Spiral\Cqrs\QueryInterface;
+
+final class CompareProfiles implements QueryInterface
+{
+    public function __construct(
+        public Uuid $baseProfileUuid,
+        public Uuid $compareProfileUuid,
+        public int $limit = 50,
+    ) {}
+}

--- a/app/modules/Profiler/Application/Query/FindProfileSummaryByUuid.php
+++ b/app/modules/Profiler/Application/Query/FindProfileSummaryByUuid.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Profiler\Application\Query;
+
+use App\Application\Domain\ValueObjects\Uuid;
+use Spiral\Cqrs\QueryInterface;
+
+final class FindProfileSummaryByUuid implements QueryInterface
+{
+    public function __construct(
+        public Uuid $profileUuid,
+    ) {}
+}

--- a/app/modules/Profiler/Interfaces/Http/Controllers/CompareProfilesAction.php
+++ b/app/modules/Profiler/Interfaces/Http/Controllers/CompareProfilesAction.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Profiler\Interfaces\Http\Controllers;
+
+use App\Application\Domain\ValueObjects\Uuid;
+use App\Application\Exception\EntityNotFoundException;
+use Modules\Profiler\Application\Query\CompareProfiles;
+use Modules\Profiler\Interfaces\Http\Request\CompareProfilesRequest;
+use Spiral\Cqrs\QueryBusInterface;
+use Spiral\Http\Exception\ClientException\NotFoundException;
+use Spiral\Router\Annotation\Route;
+
+final readonly class CompareProfilesAction
+{
+    #[Route(route: 'profiler/compare', name: 'profiler.compare', methods: ['GET'], group: 'api')]
+    public function __invoke(
+        CompareProfilesRequest $request,
+        QueryBusInterface $bus,
+    ): array {
+        try {
+            return $bus->ask(
+                new CompareProfiles(
+                    baseProfileUuid: new Uuid($request->base),
+                    compareProfileUuid: new Uuid($request->compare),
+                ),
+            );
+        } catch (EntityNotFoundException $e) {
+            throw new NotFoundException($e->getMessage());
+        }
+    }
+}

--- a/app/modules/Profiler/Interfaces/Http/Controllers/ShowSummaryAction.php
+++ b/app/modules/Profiler/Interfaces/Http/Controllers/ShowSummaryAction.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Profiler\Interfaces\Http\Controllers;
+
+use App\Application\Domain\ValueObjects\Uuid;
+use App\Application\Exception\EntityNotFoundException;
+use Modules\Profiler\Application\Query\FindProfileSummaryByUuid;
+use Spiral\Cqrs\QueryBusInterface;
+use Spiral\Http\Exception\ClientException\NotFoundException;
+use Spiral\Router\Annotation\Route;
+
+final readonly class ShowSummaryAction
+{
+    #[Route(route: 'profiler/<uuid>/summary', name: 'profiler.show.summary', methods: ['GET'], group: 'api')]
+    public function __invoke(
+        QueryBusInterface $bus,
+        Uuid $uuid,
+    ): array {
+        try {
+            return $bus->ask(new FindProfileSummaryByUuid(profileUuid: $uuid));
+        } catch (EntityNotFoundException $e) {
+            throw new NotFoundException($e->getMessage());
+        }
+    }
+}

--- a/app/modules/Profiler/Interfaces/Http/Request/CompareProfilesRequest.php
+++ b/app/modules/Profiler/Interfaces/Http/Request/CompareProfilesRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Profiler\Interfaces\Http\Request;
+
+use Spiral\Filters\Attribute\Input\Query;
+use Spiral\Filters\Model\Filter;
+use Spiral\Filters\Model\FilterDefinitionInterface;
+use Spiral\Filters\Model\HasFilterDefinition;
+use Spiral\Validator\FilterDefinition;
+
+final class CompareProfilesRequest extends Filter implements HasFilterDefinition
+{
+    #[Query]
+    public string $base = '';
+
+    #[Query]
+    public string $compare = '';
+
+    public function filterDefinition(): FilterDefinitionInterface
+    {
+        return new FilterDefinition([
+            'base' => [
+                ['notEmpty'],
+                ['string::length', 36, 36],
+            ],
+            'compare' => [
+                ['notEmpty'],
+                ['string::length', 36, 36],
+            ],
+        ]);
+    }
+}

--- a/app/modules/Profiler/Interfaces/Queries/CompareProfilesHandler.php
+++ b/app/modules/Profiler/Interfaces/Queries/CompareProfilesHandler.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Profiler\Interfaces\Queries;
+
+use Cycle\ORM\ORMInterface;
+use Modules\Profiler\Application\Query\CompareProfiles;
+use Modules\Profiler\Domain\Edge;
+use Modules\Profiler\Domain\Profile;
+use Spiral\Cqrs\Attribute\QueryHandler;
+
+final class CompareProfilesHandler
+{
+    public function __construct(
+        private ORMInterface $orm,
+    ) {}
+
+    #[QueryHandler]
+    public function __invoke(CompareProfiles $query): array
+    {
+        $baseFunctions = $this->aggregateFunctions($query->baseProfileUuid);
+        $compareFunctions = $this->aggregateFunctions($query->compareProfileUuid);
+
+        $allFunctionNames = \array_unique(\array_merge(
+            \array_keys($baseFunctions),
+            \array_keys($compareFunctions),
+        ));
+
+        $metrics = ['cpu', 'wt', 'ct', 'mu', 'pmu', 'excl_cpu', 'excl_wt', 'excl_ct', 'excl_mu', 'excl_pmu'];
+        $diff = [];
+
+        foreach ($allFunctionNames as $fn) {
+            $base = $baseFunctions[$fn] ?? null;
+            $compare = $compareFunctions[$fn] ?? null;
+
+            $row = ['function' => $fn];
+
+            foreach ($metrics as $metric) {
+                $baseVal = $base[$metric] ?? 0;
+                $compareVal = $compare[$metric] ?? 0;
+                $row['base_' . $metric] = $baseVal;
+                $row['compare_' . $metric] = $compareVal;
+                $row['diff_' . $metric] = $compareVal - $baseVal;
+            }
+
+            $diff[] = $row;
+        }
+
+        // Sort by absolute diff in exclusive wall time descending
+        \usort($diff, static fn(array $a, array $b) => \abs($b['diff_excl_wt']) <=> \abs($a['diff_excl_wt']));
+
+        return [
+            'functions' => \array_slice($diff, 0, $query->limit),
+        ];
+    }
+
+    private function aggregateFunctions(mixed $profileUuid): array
+    {
+        $profile = $this->orm->getRepository(Profile::class)->findByPK($profileUuid);
+        $functions = [];
+        $metrics = ['cpu', 'ct', 'wt', 'mu', 'pmu'];
+
+        /** @var Edge[] $edges */
+        $edges = $profile->edges;
+
+        foreach ($edges as $edge) {
+            $callee = $edge->getCallee();
+            if (!isset($functions[$callee])) {
+                $functions[$callee] = [];
+                foreach ($metrics as $metric) {
+                    $functions[$callee][$metric] = 0;
+                }
+            }
+            foreach ($metrics as $metric) {
+                $functions[$callee][$metric] += $edge->getCost()->{$metric};
+            }
+        }
+
+        // Exclusive metrics
+        foreach (\array_keys($functions) as $fn) {
+            foreach ($metrics as $metric) {
+                $functions[$fn]['excl_' . $metric] = $functions[$fn][$metric];
+            }
+        }
+
+        foreach ($edges as $edge) {
+            if (!$edge->getCaller()) {
+                continue;
+            }
+            foreach ($metrics as $metric) {
+                $field = 'excl_' . $metric;
+                if (!isset($functions[$edge->getCaller()][$field])) {
+                    continue;
+                }
+                $functions[$edge->getCaller()][$field] -= $edge->getCost()->{$metric};
+                if ($functions[$edge->getCaller()][$field] < 0) {
+                    $functions[$edge->getCaller()][$field] = 0;
+                }
+            }
+        }
+
+        return $functions;
+    }
+}

--- a/app/modules/Profiler/Interfaces/Queries/FindProfileSummaryByUuidHandler.php
+++ b/app/modules/Profiler/Interfaces/Queries/FindProfileSummaryByUuidHandler.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Profiler\Interfaces\Queries;
+
+use Cycle\ORM\ORMInterface;
+use Modules\Profiler\Application\Query\FindProfileSummaryByUuid;
+use Modules\Profiler\Domain\Edge;
+use Modules\Profiler\Domain\Profile;
+use Spiral\Cqrs\Attribute\QueryHandler;
+
+final class FindProfileSummaryByUuidHandler
+{
+    public function __construct(
+        private ORMInterface $orm,
+    ) {}
+
+    #[QueryHandler]
+    public function __invoke(FindProfileSummaryByUuid $query): array
+    {
+        $profile = $this->orm->getRepository(Profile::class)->findByPK($query->profileUuid);
+
+        $functions = [];
+        $metrics = ['cpu', 'ct', 'wt', 'mu', 'pmu'];
+
+        /** @var Edge[] $edges */
+        $edges = $profile->edges;
+
+        // Aggregate inclusive metrics per function
+        foreach ($edges as $edge) {
+            $callee = $edge->getCallee();
+
+            if (!isset($functions[$callee])) {
+                $functions[$callee] = ['function' => $callee];
+                foreach ($metrics as $metric) {
+                    $functions[$callee][$metric] = 0;
+                }
+            }
+
+            foreach ($metrics as $metric) {
+                $functions[$callee][$metric] += $edge->getCost()->{$metric};
+            }
+        }
+
+        // Overall totals from main()
+        $overallTotals = [];
+        foreach ($metrics as $metric) {
+            $overallTotals[$metric] = $functions['main()'][$metric] ?? 0;
+        }
+        $overallTotals['ct'] = 0;
+        foreach ($functions as $m) {
+            $overallTotals['ct'] += $m['ct'];
+        }
+
+        // Initialize exclusive metrics
+        foreach (\array_keys($functions) as $function) {
+            foreach ($metrics as $metric) {
+                $functions[$function]['excl_' . $metric] = $functions[$function][$metric];
+            }
+        }
+
+        // Subtract children's inclusive from parent's exclusive
+        foreach ($edges as $edge) {
+            if (!$edge->getCaller()) {
+                continue;
+            }
+
+            foreach ($metrics as $metric) {
+                $field = 'excl_' . $metric;
+                if (!isset($functions[$edge->getCaller()][$field])) {
+                    continue;
+                }
+                $functions[$edge->getCaller()][$field] -= $edge->getCost()->{$metric};
+                if ($functions[$edge->getCaller()][$field] < 0) {
+                    $functions[$edge->getCaller()][$field] = 0;
+                }
+            }
+        }
+
+        $fnList = \array_values($functions);
+
+        // Slowest function by exclusive wall time
+        \usort($fnList, static fn(array $a, array $b) => ($b['excl_wt'] ?? 0) <=> ($a['excl_wt'] ?? 0));
+        $slowest = $fnList[0] ?? null;
+
+        // Memory hotspot by exclusive memory usage
+        \usort($fnList, static fn(array $a, array $b) => ($b['excl_mu'] ?? 0) <=> ($a['excl_mu'] ?? 0));
+        $memoryHotspot = $fnList[0] ?? null;
+
+        // Most called function (exclude main)
+        $fnListNoMain = \array_filter($fnList, static fn(array $f) => $f['function'] !== 'main()');
+        \usort($fnListNoMain, static fn(array $a, array $b) => ($b['ct'] ?? 0) <=> ($a['ct'] ?? 0));
+        $mostCalled = \array_values($fnListNoMain)[0] ?? null;
+
+        return [
+            'overall_totals' => $overallTotals,
+            'slowest_function' => $slowest ? [
+                'function' => $slowest['function'],
+                'excl_wt' => $slowest['excl_wt'],
+                'p_excl_wt' => $overallTotals['wt'] > 0
+                    ? \round($slowest['excl_wt'] / $overallTotals['wt'] * 100, 1)
+                    : 0,
+            ] : null,
+            'memory_hotspot' => $memoryHotspot ? [
+                'function' => $memoryHotspot['function'],
+                'excl_mu' => $memoryHotspot['excl_mu'],
+                'p_excl_mu' => $overallTotals['mu'] > 0
+                    ? \round($memoryHotspot['excl_mu'] / $overallTotals['mu'] * 100, 1)
+                    : 0,
+            ] : null,
+            'most_called' => $mostCalled ? [
+                'function' => $mostCalled['function'],
+                'ct' => $mostCalled['ct'],
+            ] : null,
+        ];
+    }
+}

--- a/tests/Unit/Modules/Events/Domain/CacheEventRepositoryTest.php
+++ b/tests/Unit/Modules/Events/Domain/CacheEventRepositoryTest.php
@@ -134,4 +134,52 @@ final class CacheEventRepositoryTest extends DatabaseTestCase
         $this->assertSame((string) $event2->getUuid(), (string) $result[1]->getUuid());
         $this->assertSame((string) $event3->getUuid(), (string) $result[2]->getUuid());
     }
+
+    public function testPinEvent(): void
+    {
+        $event = $this->createEvent();
+
+        $this->assertTrue($this->repository->pin((string) $event->getUuid()));
+
+        $this->cleanIdentityMap();
+        $found = $this->repository->findByPK($event->getUuid());
+        $this->assertTrue($found->isPinned());
+    }
+
+    public function testUnpinEvent(): void
+    {
+        $event = $this->createEvent();
+        $this->repository->pin((string) $event->getUuid());
+
+        $this->assertTrue($this->repository->unpin((string) $event->getUuid()));
+
+        $this->cleanIdentityMap();
+        $found = $this->repository->findByPK($event->getUuid());
+        $this->assertFalse($found->isPinned());
+    }
+
+    public function testDeleteAllSkipsPinnedEvents(): void
+    {
+        $event1 = $this->createEvent();
+        $event2 = $this->createEvent();
+        $this->repository->pin((string) $event1->getUuid());
+
+        $this->repository->deleteAll([]);
+
+        $this->assertCount(1, \iterator_to_array($this->repository->findAll()));
+
+        $this->cleanIdentityMap();
+        $found = $this->repository->findByPK($event1->getUuid());
+        $this->assertNotNull($found);
+        $this->assertTrue($found->isPinned());
+    }
+
+    public function testDeleteByPKSkipsPinnedEvent(): void
+    {
+        $event = $this->createEvent();
+        $this->repository->pin((string) $event->getUuid());
+
+        $this->assertFalse($this->repository->deleteByPK((string) $event->getUuid()));
+        $this->assertCount(1, \iterator_to_array($this->repository->findAll()));
+    }
 }


### PR DESCRIPTION
## Summary
- **Searchable text**: `toSearchableText()` on all event type mappers (Sentry, Profiler, Inspector, Smtp, Monolog, HttpDumps), exposed in preview API and WS broadcasts
- **Profiler insights**: Summary endpoint (`GET /api/profiler/{id}/summary`) with slowest function, memory hotspot, most-called. Comparison endpoint (`GET /api/profiler/compare`) with side-by-side diff
- **Pinned events**: `is_pinned` column + migration, `POST/DELETE /api/event/{uuid}/pin`, deleteAll/deleteByPK skip pinned events
- **Auto-projects**: StoreEventHandler auto-creates projects when project key doesn't exist
- **Upsert optimization**: Replaced ORM SELECT+INSERT with raw INSERT/UPDATE in EventRepository

## Test plan
- [x] Verify `searchable_text` appears in preview API and WS broadcasts for all event types
- [x] Test profiler summary and comparison endpoints with real profile data
- [x] Test pin/unpin endpoints and verify pinned events survive clear
- [x] Test auto-project creation by sending events with new project keys
- [x] Run `vendor/bin/phpunit` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)