### PR TITLE
fix: decode RFC 2047 encoded-word in SMTP subject headers

### DIFF
--- a/modules/smtp/handler.go
+++ b/modules/smtp/handler.go
@@ -199,9 +199,16 @@ func parseEmail(raw []byte, recipients []string) (*ParsedEmail, []parsedAttachme
 		bcc = []string{}
 	}
 
+	// Decode RFC 2047 encoded-word in Subject header (e.g. =?utf-8?Q?...?=).
+	subject := msg.Header.Get("Subject")
+	dec := new(mime.WordDecoder)
+	if decoded, err := dec.DecodeHeader(subject); err == nil {
+		subject = decoded
+	}
+
 	parsed := &ParsedEmail{
 		ID:      msgID,
-		Subject: msg.Header.Get("Subject"),
+		Subject: subject,
 		Raw:     string(raw),
 		From:    parseAddresses(msg.Header, "From"),
 		To:      to,

--- a/modules/smtp/handler_test.go
+++ b/modules/smtp/handler_test.go
@@ -165,6 +165,48 @@ func TestParseAddresses(t *testing.T) {
 	})
 }
 
+func TestParseEmail_RFC2047Subject(t *testing.T) {
+	tests := []struct {
+		name    string
+		subject string
+		want    string
+	}{
+		{
+			name:    "Q-encoded UTF-8",
+			subject: "=?utf-8?Q?Handled_with_Care_by_Chuck_Norris=E2=80=94Your_Package?=",
+			want:    "Handled with Care by Chuck Norris\u2014Your Package",
+		},
+		{
+			name:    "B-encoded UTF-8",
+			subject: "=?utf-8?B?SGVsbG8gV29ybGQ=?=",
+			want:    "Hello World",
+		},
+		{
+			name:    "mixed encoded and plain",
+			subject: "Handled with Care by Chuck =?utf-8?Q?Norris=E2=80=94Your?= Package Is Shipped!",
+			want:    "Handled with Care by Chuck Norris\u2014Your Package Is Shipped!",
+		},
+		{
+			name:    "plain subject unchanged",
+			subject: "Plain Subject",
+			want:    "Plain Subject",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := []byte("From: sender@example.com\r\nTo: recipient@example.com\r\nSubject: " + tt.subject + "\r\nContent-Type: text/plain\r\n\r\ntest body")
+			parsed, _, err := parseEmail(raw, []string{"recipient@example.com"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if parsed.Subject != tt.want {
+				t.Errorf("Subject = %q, want %q", parsed.Subject, tt.want)
+			}
+		})
+	}
+}
+
 func TestPreviewMapper(t *testing.T) {
 	m := &previewMapper{}
 


### PR DESCRIPTION
## What
Decode MIME encoded-words (RFC 2047) in SMTP email subject headers before storing them. Subjects like `=?utf-8?Q?Norris=E2=80=94Your?=` are now correctly decoded to their readable form.

## Why
Non-ASCII characters in email subjects arrive as RFC 2047 encoded-words. Without decoding, they appear garbled in the UI (e.g. `=?utf-8?Q?...?=` instead of readable text).

## How
- Added `mime.WordDecoder.DecodeHeader()` call in `parseEmail()` before assigning the subject field
- The `mime` package was already imported — no new dependencies

## Testing
- Added `TestParseEmail_RFC2047Subject` with 4 cases: Q-encoded, B-encoded, mixed encoded/plain, and plain subject
- All existing SMTP tests continue to pass: `go test ./modules/smtp/`