### PR TITLE
feat: inject server version from GitHub release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,8 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: "0"
         run: |
-          go build -ldflags="-s -w" -o buggregator-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/buggregator
+          VERSION=${GITHUB_REF_NAME#v}
+          go build -ldflags="-s -w -X main.version=${VERSION}" -o buggregator-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/buggregator
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -141,6 +142,8 @@ jobs:
             ${{ steps.meta-dockerhub.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,8 @@ COPY --from=php-builder /php/vardumper-parser modules/vardumper/bin/vardumper-pa
 # Copy frontend into the embed location
 COPY --from=frontend /frontend/ internal/frontend/dist/
 
-RUN CGO_ENABLED=0 go build -o buggregator ./cmd/buggregator
+ARG VERSION=dev
+RUN CGO_ENABLED=0 go build -ldflags="-s -w -X main.version=${VERSION}" -o buggregator ./cmd/buggregator
 
 # Stage 4: Final minimal image
 FROM alpine:3.20

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ FRONTEND_VERSION ?= 1.29.1
 FRONTEND_URL = https://github.com/buggregator/frontend/releases/download/$(FRONTEND_VERSION)/frontend-$(FRONTEND_VERSION).zip
 FRONTEND_DIR = internal/frontend/dist
 BINARY = buggregator
+VERSION ?= dev
+LDFLAGS = -s -w -X main.version=$(VERSION)
 
 # PHP VarDumper binary build
 PHP_DIR = php/vardumper
@@ -113,7 +115,7 @@ deps:
 build: deps
 	@if [ ! -f $(FRONTEND_DIR)/index.html ]; then $(MAKE) frontend; fi
 	@if [ -z "$$(ls $(PHP_BIN_DIR)/vardumper-parser-* 2>/dev/null)" ]; then $(MAKE) vardumper-php; fi
-	go build -o $(BINARY) ./cmd/buggregator
+	go build -ldflags="$(LDFLAGS)" -o $(BINARY) ./cmd/buggregator
 	@echo "Built $(BINARY) ($$(du -h $(BINARY) | cut -f1))"
 
 # Cross-compile for a specific platform
@@ -121,16 +123,16 @@ build: deps
 build-cross: deps
 	@if [ ! -f $(FRONTEND_DIR)/index.html ]; then $(MAKE) frontend; fi
 	@if [ ! -f $(PHP_BIN_DIR)/vardumper-parser-$(GOOS)-$(GOARCH) ]; then $(MAKE) vardumper-$(GOOS)-$(GOARCH); fi
-	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o $(BINARY)-$(GOOS)-$(GOARCH) ./cmd/buggregator
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -ldflags="$(LDFLAGS)" -o $(BINARY)-$(GOOS)-$(GOARCH) ./cmd/buggregator
 	@echo "Built $(BINARY)-$(GOOS)-$(GOARCH) ($$(du -h $(BINARY)-$(GOOS)-$(GOARCH) | cut -f1))"
 
 # Build all platforms
 release: deps frontend vardumper-all
-	GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o $(BINARY)-linux-amd64 ./cmd/buggregator
-	GOOS=linux GOARCH=arm64 go build -ldflags="-s -w" -o $(BINARY)-linux-arm64 ./cmd/buggregator
-	GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w" -o $(BINARY)-darwin-amd64 ./cmd/buggregator
-	GOOS=darwin GOARCH=arm64 go build -ldflags="-s -w" -o $(BINARY)-darwin-arm64 ./cmd/buggregator
-	GOOS=windows GOARCH=amd64 go build -ldflags="-s -w" -o $(BINARY)-windows-amd64.exe ./cmd/buggregator
+	GOOS=linux GOARCH=amd64 go build -ldflags="$(LDFLAGS)" -o $(BINARY)-linux-amd64 ./cmd/buggregator
+	GOOS=linux GOARCH=arm64 go build -ldflags="$(LDFLAGS)" -o $(BINARY)-linux-arm64 ./cmd/buggregator
+	GOOS=darwin GOARCH=amd64 go build -ldflags="$(LDFLAGS)" -o $(BINARY)-darwin-amd64 ./cmd/buggregator
+	GOOS=darwin GOARCH=arm64 go build -ldflags="$(LDFLAGS)" -o $(BINARY)-darwin-arm64 ./cmd/buggregator
+	GOOS=windows GOARCH=amd64 go build -ldflags="$(LDFLAGS)" -o $(BINARY)-windows-amd64.exe ./cmd/buggregator
 	@echo "Release binaries built."
 
 run: build

--- a/cmd/buggregator/main.go
+++ b/cmd/buggregator/main.go
@@ -24,6 +24,9 @@ import (
 	"github.com/buggregator/go-buggregator/modules/webhooks"
 )
 
+// version is set at build time via -ldflags "-X main.version=...".
+var version = "dev"
+
 func main() {
 	// MCP proxy subcommand: "buggregator mcp" bridges stdio to the running instance.
 	if len(os.Args) > 1 && os.Args[1] == "mcp" {
@@ -41,6 +44,7 @@ func main() {
 	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})))
 
 	cfg := app.LoadConfig()
+	cfg.Version = version
 
 	db, err := storage.Open(cfg.DatabaseDSN)
 	if err != nil {

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -160,7 +160,7 @@ func LoadConfig() Config {
 	var configFile string
 	flag.StringVar(&configFile, "config", "", "Path to config file (buggregator.yaml)")
 
-	cfg := Config{Version: "1.0.0"}
+	cfg := Config{}
 
 	flag.StringVar(&cfg.Server.Addr, "http-addr", "", "HTTP listen address")
 	flag.StringVar(&cfg.Database.DSN, "db", "", "SQLite DSN")


### PR DESCRIPTION
## What
Replace the hardcoded `1.0.0` server version with build-time injection via Go `-ldflags`. When a GitHub release is created (e.g. tag `v1.2.3`), the server version automatically becomes `1.2.3`.

## Why
The server always reported version `1.0.0` regardless of the actual release. This made it impossible to tell which version was running from the API (`/api/version`, `/api/settings`).

## How
- Added `var version = "dev"` in `cmd/buggregator/main.go`, overridden via `-X main.version=...`
- Removed hardcoded `"1.0.0"` from `config.go`
- Updated all build targets to inject the version:
  - **CI release** (`release.yml`): extracts version from `GITHUB_REF_NAME` (strips `v` prefix)
  - **Docker** (`Dockerfile`): accepts `VERSION` build-arg, passed from `docker/metadata-action` output
  - **Makefile**: uses `VERSION` variable (defaults to `dev`), e.g. `make build VERSION=1.2.3`

## Testing
- `go build ./...` compiles successfully
- `go test ./...` all tests pass
- Local builds default to `"dev"` version — no breakage for development