### PR TITLE
chore: bump frontend version to 1.31.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
   packages: write
 
 env:
-  FRONTEND_VERSION: "1.30.0"
+  FRONTEND_VERSION: "1.31.0"
   PHP_VERSION: "8.4.19"
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN ARCH=$(case ${TARGETARCH} in amd64) echo "x86_64";; arm64) echo "aarch64";; 
 
 # Stage 2: Download frontend
 FROM alpine:3.20 AS frontend
-ARG FRONTEND_VERSION=1.29.1
+ARG FRONTEND_VERSION=1.31.0
 RUN apk add --no-cache curl unzip \
     && mkdir -p /frontend \
     && curl -sL "https://github.com/buggregator/frontend/releases/download/${FRONTEND_VERSION}/frontend-${FRONTEND_VERSION}.zip" -o /tmp/fe.zip \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-FRONTEND_VERSION ?= 1.29.1
+FRONTEND_VERSION ?= 1.31.0
 FRONTEND_URL = https://github.com/buggregator/frontend/releases/download/$(FRONTEND_VERSION)/frontend-$(FRONTEND_VERSION).zip
 FRONTEND_DIR = internal/frontend/dist
 BINARY = buggregator


### PR DESCRIPTION
## What
Updates the frontend version from 1.29.1/1.30.0 to 1.31.0 across all build targets.

## How
- `Makefile`: 1.29.1 → 1.31.0
- `Dockerfile`: 1.29.1 → 1.31.0
- `.github/workflows/release.yml`: 1.30.0 → 1.31.0