### PR TITLE
fix: call NotifyEventStored in MCP profiler test

### DIFF
--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -72,6 +72,7 @@ func ingestViaHandler(t *testing.T, reg *module.Registry, store event.Store, req
 			if err := store.Store(context.Background(), ev); err != nil {
 				t.Fatal(err)
 			}
+			reg.NotifyEventStored(ev)
 			return ev.UUID
 		}
 	}


### PR DESCRIPTION
## What
Adds the missing `reg.NotifyEventStored(ev)` call in the MCP test's `ingestViaHandler` helper so profiler-specific tables are populated before MCP tool queries run.

## Why
PR #328 moved `storeProfile` from the profiler handler's `Handle()` into `OnEventStored()`. The MCP test bypasses the HTTP server's `EventService` and calls `store.Store()` directly, which doesn't trigger module hooks — leaving the `profiles` and `profile_edges` tables empty and causing `TestMCP_ProfilerEndToEnd` to fail in CI.

## Testing
`go test ./internal/mcp/ -run TestMCP_ProfilerEndToEnd -v` passes. Full suite (`go test ./...`) passes.