### PR TITLE
fix: resolve ServeMux conflict between attachments and SMTP message routes

### DIFF
--- a/internal/server/http/attachments.go
+++ b/internal/server/http/attachments.go
@@ -9,18 +9,26 @@ import (
 )
 
 // RegisterAttachmentAPI registers attachment list/download/preview endpoints.
+//
+// Routes are namespaced under a literal `attachments` segment rather than
+// `/api/{module}/{eventUuid}/attachments/...`. The previous layout used a
+// wildcard at position 2, which collides with module routes like
+// `/api/smtp/message/{uuid}/raw` (both 4-segment patterns, neither more
+// specific) and made the server panic at startup.
 func RegisterAttachmentAPI(mux *http.ServeMux, db *sql.DB, store *storage.AttachmentStore) {
 	// SMTP attachments.
-	mux.HandleFunc("GET /api/smtp/{uuid}/attachments", listAttachments(db, "smtp_attachments"))
-	mux.HandleFunc("GET /api/smtp/{eventUuid}/attachments/{uuid}", downloadAttachment(db, store, "smtp_attachments"))
-	mux.HandleFunc("GET /api/smtp/{eventUuid}/attachments/preview/{uuid}", previewAttachment(db, store, "smtp_attachments"))
+	registerAttachmentsForModule(mux, db, store, "/api/smtp/attachments", "smtp_attachments")
 
-	// HTTP Dump attachments (support both /http-dump/ and /http-dumps/ paths).
-	for _, prefix := range []string{"/api/http-dump/", "/api/http-dumps/"} {
-		mux.HandleFunc("GET "+prefix+"{uuid}/attachments", listAttachments(db, "http_dump_attachments"))
-		mux.HandleFunc("GET "+prefix+"{eventUuid}/attachments/{uuid}", downloadAttachment(db, store, "http_dump_attachments"))
-		mux.HandleFunc("GET "+prefix+"{eventUuid}/attachments/preview/{uuid}", previewAttachment(db, store, "http_dump_attachments"))
-	}
+	// HTTP Dump attachments (support both /http-dump/ and /http-dumps/ paths
+	// for backwards compatibility with existing clients).
+	registerAttachmentsForModule(mux, db, store, "/api/http-dump/attachments", "http_dump_attachments")
+	registerAttachmentsForModule(mux, db, store, "/api/http-dumps/attachments", "http_dump_attachments")
+}
+
+func registerAttachmentsForModule(mux *http.ServeMux, db *sql.DB, store *storage.AttachmentStore, prefix, table string) {
+	mux.HandleFunc("GET "+prefix+"/{uuid}", listAttachments(db, table))
+	mux.HandleFunc("GET "+prefix+"/{eventUuid}/{uuid}", downloadAttachment(db, store, table))
+	mux.HandleFunc("GET "+prefix+"/{eventUuid}/preview/{uuid}", previewAttachment(db, store, table))
 }
 
 func listAttachments(db *sql.DB, table string) http.HandlerFunc {

--- a/internal/server/http/attachments_test.go
+++ b/internal/server/http/attachments_test.go
@@ -1,0 +1,41 @@
+package http_test
+
+import (
+	"net/http"
+	"testing"
+
+	serverhttp "github.com/buggregator/go-buggregator/internal/server/http"
+	"github.com/buggregator/go-buggregator/internal/storage"
+	smtpmod "github.com/buggregator/go-buggregator/modules/smtp"
+)
+
+// TestRegisterAttachmentAPI_NoConflictWithSMTPRoutes ensures the attachment
+// routes can co-exist on the same mux as the SMTP module's message routes.
+//
+// Prior layout used `/api/smtp/{eventUuid}/attachments/{uuid}` which collides
+// with `/api/smtp/message/{uuid}/raw` (both 4-segment patterns, neither more
+// specific), and Go's ServeMux panics at registration time. This test fails
+// the same way if the conflict ever returns.
+func TestRegisterAttachmentAPI_NoConflictWithSMTPRoutes(t *testing.T) {
+	db, err := storage.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	attachments := storage.NewAttachmentStore("memory", "")
+	mux := http.NewServeMux()
+
+	// Order intentionally interleaves attachment + SMTP module routes to
+	// mirror app startup.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("route registration panicked: %v", r)
+		}
+	}()
+
+	serverhttp.RegisterAttachmentAPI(mux, db, attachments)
+
+	mod := smtpmod.New(":0", attachments, db)
+	mod.RegisterRoutes(mux, nil)
+}

--- a/modules/httpdumps/handler.go
+++ b/modules/httpdumps/handler.go
@@ -106,7 +106,7 @@ func (h *handler) Handle(r *http.Request) (*event.Incoming, error) {
 						"name": fh.Filename,
 						"size": len(content),
 						"mime": mime,
-						"uri":  "/api/http-dump/" + eventUUID + "/attachments/" + attUUID,
+						"uri":  "/api/http-dump/attachments/" + eventUUID + "/" + attUUID,
 					})
 				}
 			}


### PR DESCRIPTION
## What
Server panics at boot with `pattern "GET /api/smtp/{eventUuid}/attachments/{uuid}" ... conflicts with pattern "GET /api/smtp/message/{uuid}/raw"`. This PR nests the attachment routes under a literal `/attachments/` segment so they no longer collide with the SMTP module's 4-segment routes.

## Why
The attachment API was registered as `/api/{module}/{eventUuid}/attachments/{uuid}` — wildcard at position 2. After [#334](https://github.com/buggregator/server/pull/334) added `/api/smtp/message/{uuid}/raw`, both 4-segment patterns claim `/api/smtp/message/attachments/raw` and Go 1.22's `ServeMux` refuses to register them.

```
panic: pattern "GET /api/smtp/{eventUuid}/attachments/{uuid}" ...
       conflicts with pattern "GET /api/smtp/message/{uuid}/raw":
       But neither is more specific than the other.
```

## How
- `internal/server/http/attachments.go` — routes are now `/api/{module}/attachments/{eventUuid}[/{uuid}][/preview/{uuid}]`. The `attachments` literal at position 2 makes them disjoint from any future module-specific route at position 2.
- `modules/httpdumps/handler.go:109` — the generated attachment URI follows the new layout.
- **Companion frontend PR**: [buggregator/frontend#282](https://github.com/buggregator/frontend) updates `src/shared/lib/io/use-attachments.ts` to call the new paths. Both PRs must land together.

## Testing
- `internal/server/http/attachments_test.go` (new) — registers `RegisterAttachmentAPI` and the SMTP module on the same mux and asserts no panic. Without the fix this panics at registration.
- `go test ./... -count=1` clean; `go vet ./...` clean.

## Note
PR [#335](https://github.com/buggregator/server/pull/335) is independent and can be rebased on top of this once it lands.